### PR TITLE
[Feature] Basic Button 컴포넌트 구현

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -52,8 +52,7 @@ struct SolidIconButton: ButtonStyle {
     var systemName: String
     
     func makeBody(configuration: Configuration) -> some View {
-        
-        return HStack (spacing: 6) {
+        HStack (spacing: 6) {
             Spacer()
             
             configuration.label

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -8,46 +8,42 @@
 
 import SwiftUI
 
-struct BasicButton: ButtonStyle {
-    
-    var fontType = BbangFont.body2
-    var textColor = Color("PrimaryNormal")
-    var verticalPadding: CGFloat = 9
-    var buttonColor = Color(.clear)
-    var customCornerRadius: CGFloat = 16
-    
+struct OutlinedMediumButton: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .applyFont(font: fontType)
-            .foregroundStyle(textColor)
-            .padding(.init(vertical: verticalPadding))
+            .applyFont(font: .body2)
+            .foregroundStyle(Color(BBANGZIPAsset.Assets.primaryNormal.color))
+            .padding(.vertical, 9)
             .frame(maxWidth: .infinity)
-            .background(buttonColor)
-            .cornerRadius(customCornerRadius)
-            .overlay(RoundedRectangle(cornerRadius: customCornerRadius)
-                .stroke(Color("LineStrong"), lineWidth: 1)
+            .cornerRadius(16)
+            .overlay(RoundedRectangle(cornerRadius: 16)
+                .stroke(Color(BBANGZIPAsset.Assets.lineStrong.color), lineWidth: 1)
             )
     }
 }
 
-extension EdgeInsets {
-    var verticalInset: CGFloat { self.top + self.bottom }
-    
-    static func vertical(_ vertical: CGFloat, left: CGFloat = 0, right: CGFloat = 0) -> UIEdgeInsets {
-        UIEdgeInsets(
-            top: vertical,
-            left: left,
-            bottom: vertical,
-            right: right
-        )
+struct OutlinedLargeButton: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .applyFont(font: .body1)
+            .foregroundStyle(Color(BBANGZIPAsset.Assets.primaryNormal.color))
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity)
+            .cornerRadius(24)
+            .overlay(RoundedRectangle(cornerRadius: 24)
+                .stroke(Color(BBANGZIPAsset.Assets.lineStrong.color), lineWidth: 1)
+            )
     }
-    
-    init(vertical: CGFloat = 0) {
-        self = EdgeInsets(
-            top: vertical,
-            leading: 0,
-            bottom: vertical,
-            trailing: 0
-        )
+}
+
+struct SolidButton: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .applyFont(font: .body1)
+            .foregroundStyle(Color(BBANGZIPAsset.Assets.staticWhite.color))
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity)
+            .background(Color(BBANGZIPAsset.Assets.primaryNormal.color))
+            .cornerRadius(24)
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -11,14 +11,19 @@ import SwiftUI
 struct BasicButton: ButtonStyle {
     
     var fontType = BbangFont.body2
+    var textColor = Color("PrimaryNormal")
     var verticalPadding: CGFloat = 9
+    var buttonColor = Color(.clear)
     var customCornerRadius: CGFloat = 16
     
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .applyFont(font: fontType)
+            .foregroundStyle(textColor)
             .padding(.init(vertical: verticalPadding))
             .frame(maxWidth: .infinity)
+            .background(buttonColor)
+            .cornerRadius(customCornerRadius)
             .overlay(RoundedRectangle(cornerRadius: customCornerRadius)
                 .stroke(Color("LineStrong"), lineWidth: 1)
             )

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -49,7 +49,11 @@ struct SolidButton: ButtonStyle {
 }
 
 struct SolidIconButton: ButtonStyle {
-    var systemName: String
+    private let systemName: String
+    
+    init(systemName: String) {
+        self.systemName = systemName
+    }
     
     func makeBody(configuration: Configuration) -> some View {
         HStack (spacing: 6) {

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct OutlinedButton: ButtonStyle {
+struct BasicButton: ButtonStyle {
     
     var fontType = BbangFont.body2
     var verticalPadding: CGFloat = 9

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -1,5 +1,5 @@
 //
-//  OutlinedButton.swift
+//  BasicButton.swift
 //  BBANGZIP
 //
 //  Created by 최유빈 on 1/12/25.

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/BasicButton/BasicButton.swift
@@ -47,3 +47,28 @@ struct SolidButton: ButtonStyle {
             .cornerRadius(24)
     }
 }
+
+struct SolidIconButton: ButtonStyle {
+    var systemName: String
+    
+    func makeBody(configuration: Configuration) -> some View {
+        
+        return HStack (spacing: 6) {
+            Spacer()
+            
+            configuration.label
+                .applyFont(font: .body1)
+                .foregroundStyle(Color(BBANGZIPAsset.Assets.staticWhite.color))
+                .padding(.vertical, 16)
+            
+            Image(systemName: systemName)
+                .foregroundStyle(Color(BBANGZIPAsset.Assets.staticWhite.color))
+                .padding(.vertical, 18)
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color(BBANGZIPAsset.Assets.primaryNormal.color))
+        .cornerRadius(24)
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/OutlinedButton/OutlinedButton.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/OutlinedButton/OutlinedButton.swift
@@ -1,0 +1,48 @@
+//
+//  OutlinedButton.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/12/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct OutlinedButton: ButtonStyle {
+    
+    var fontType = BbangFont.body2
+    var verticalPadding: CGFloat = 9
+    var customCornerRadius: CGFloat = 16
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .applyFont(font: fontType)
+            .padding(.init(vertical: verticalPadding))
+            .frame(maxWidth: .infinity)
+            .overlay(RoundedRectangle(cornerRadius: customCornerRadius)
+                .stroke(Color("LineStrong"), lineWidth: 1)
+            )
+    }
+}
+
+extension EdgeInsets {
+    var verticalInset: CGFloat { self.top + self.bottom }
+    
+    static func vertical(_ vertical: CGFloat, left: CGFloat = 0, right: CGFloat = 0) -> UIEdgeInsets {
+        UIEdgeInsets(
+            top: vertical,
+            left: left,
+            bottom: vertical,
+            right: right
+        )
+    }
+    
+    init(vertical: CGFloat = 0) {
+        self = EdgeInsets(
+            top: vertical,
+            leading: 0,
+            bottom: vertical,
+            trailing: 0
+        )
+    }
+}


### PR DESCRIPTION
## 🥖 What is the PR?

- 컴포넌트 상 SolidButton, SolidIconButton, OutlinedLargeButton, OutlinedMediumButton 을 BasicButton 내 각각의 ButtonStyle로 구현하였습니다.

## 🥐 Changes

- SolidButton
```
struct SolidButton: ButtonStyle {
    func makeBody(configuration: Configuration) -> some View {
        configuration.label
            .applyFont(font: .body1)
            .foregroundStyle(Color(BBANGZIPAsset.Assets.staticWhite.color))
            .padding(.vertical, 16)
            .frame(maxWidth: .infinity)
            .background(Color(BBANGZIPAsset.Assets.primaryNormal.color))
            .cornerRadius(24)
    }
}
```

- SolidIconButton
```
struct SolidIconButton: ButtonStyle {
    var systemName: String
    
    func makeBody(configuration: Configuration) -> some View {
        
        return HStack (spacing: 6) {
            Spacer()
            
            configuration.label
                .applyFont(font: .body1)
                .foregroundStyle(Color(BBANGZIPAsset.Assets.staticWhite.color))
                .padding(.vertical, 16)
            
            Image(systemName: systemName)
                .foregroundStyle(Color(BBANGZIPAsset.Assets.staticWhite.color))
                .padding(.vertical, 18)
            
            Spacer()
        }
        .frame(maxWidth: .infinity)
        .background(Color(BBANGZIPAsset.Assets.primaryNormal.color))
        .cornerRadius(24)
    }
}
```

- OutlinedLargeButton
```
struct OutlinedLargeButton: ButtonStyle {
    func makeBody(configuration: Configuration) -> some View {
        configuration.label
            .applyFont(font: .body1)
            .foregroundStyle(Color(BBANGZIPAsset.Assets.primaryNormal.color))
            .padding(.vertical, 16)
            .frame(maxWidth: .infinity)
            .cornerRadius(24)
            .overlay(RoundedRectangle(cornerRadius: 24)
                .stroke(Color(BBANGZIPAsset.Assets.lineStrong.color), lineWidth: 1)
            )
    }
}
```

- OutlinedMediumButton
```
struct OutlinedMediumButton: ButtonStyle {
    func makeBody(configuration: Configuration) -> some View {
        configuration.label
            .applyFont(font: .body2)
            .foregroundStyle(Color(BBANGZIPAsset.Assets.primaryNormal.color))
            .padding(.vertical, 9)
            .frame(maxWidth: .infinity)
            .cornerRadius(16)
            .overlay(RoundedRectangle(cornerRadius: 16)
                .stroke(Color(BBANGZIPAsset.Assets.lineStrong.color), lineWidth: 1)
            )
    }
}
```

## 🥯 Thoughts

분기 처리를 어떤 방식으로 하여 편리하게 사용할 수 있을까 고민하였습니다.
기존 OutlinedButton만을 구현하였을 때는 주로 사용되는 OutlinedMediumButton 기준으로 verticalPadding, fontType을 매개변수로 주입하여 OutlinedLargeButton을 구현할 수 있도록 하였습니다.

하지만 SolidButton을 하나의 컴포넌트로 함께 묶은 뒤에는 SolidButton을 구현하기 위해서는 매개변수로 verticalPadding, fontType은 물론 background(Color), configuration.label의 foregroundStyle(Color)에 해당하는 color도 매개변수로 주입해줘야 하므로 SolidButton이 자주 사용되는 반면에 사용할 때 마다 많은 매개변수 주입을 필요로 한다는 것을 알았습니다.

그래서 각기 다른 ButtonStyle로 나누어 구분하여, 컴포넌트를 불러와서 사용할때 최대한 간단한 방식으로 사용할 수 있도록 구현하였습니다.

또한 icon이 포함된 SolidButton같은 경우에는, SolidIconButton이라는 하나의 ButtonStyle로 지정 후 makeBody 함수 반환값으로 HStack을 전달하여 아이콘과 텍스트를 함께 사용할 수 있도록 구현하였습니다
이미지의 크기 같은 경우는, Image(systemName:)에 .padding(.vertical, 18)을 지정하여 세로를 줄이며, 따로 .resizable()을 하지 않아 애플에서 제공하는 기본 시스템 이미지 비율을 가져와 가로 비율을 맞출 수 있도록 하였습니다.

## 🥪 Screenshot

<img width="394" alt="image" src="https://github.com/user-attachments/assets/23e7a818-ad88-4370-ac72-9534793270e6" />

- 위에서 아래로, OutlinedMediumButton, OutlinedLargeButton, SolidButton, SolidIconButton 

## 🥨 To Reviewers

버튼 사용법 입니다.

```
struct test: View {
    var body: some View {
        VStack {
            // OutlinedMediumButton
            Button("등록하기") {
                
            }
            .buttonStyle(OutlinedMediumButton())
            .padding(.horizontal, 20)
            
            // OutlinedLargeButton
            Button("취소") {
                
            }
            .buttonStyle(OutlinedLargeButton())
            .padding(.horizontal, 20)
            
            // SolidButton
            Button("확인") {
                
            }
            .buttonStyle(SolidButton())
            .padding(.horizontal, 20)
            
            // SolidIconButton
            Button("다음으로") {
                
            }
            .buttonStyle(SolidIconButton(systemName: "chevron.right"))
            .padding(.horizontal, 20)
            
        }
    }
}
```

- SolidIconButton을 제외하고는 Button(text) { action } 로 버튼의 텍스트를 지정하고 .buttonStyle(OutlinedMediumButton())과 같이 버튼 스타일을 지정하여 사용합니다.
- SolidIconButton은 systemImage의 네임을 매개변수로 받아야 하므로, Button(text) { action } 으로 지정 후, .buttonStyle(SolidIconButton(systemName: "chevron.right")) 과 같이 systemImage를 지정하여 사용합니다.
- 또한 buttonStyle내의 width를 maxWidth(.infinity)로 설정하였기 때문에, View내의 좌, 우 패딩을 고려하여 .padding(.horizontal, %d) , 또는 leading, trailing padding을 따로 .padding(.leading, %d), .padding(.trailing, $d) 로 버튼의 width를 조정할 수 있습니다.

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #5 

## 레퍼런스
- https://nsios.tistory.com/178
- https://medium.com/@mugwort28/%ED%8E%B8%EB%A6%AC%ED%95%9C-swiftui-custom-button-%EB%A7%8C%EB%93%A4%EA%B8%B0-feat-navigationlink-d06363cc7969
- https://ios-development.tistory.com/1075
- https://onelife2live.tistory.com/43