### PR TITLE
[Feature] Homies 컴포넌트 구현

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Balloon.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Balloon.swift
@@ -41,7 +41,10 @@ struct Balloon: View {
                     Image(leftIcon)
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 16, height: 16)
+                        .frame(
+                            width: 16,
+                            height: 16
+                        )
                 }
                 
                 CustomText(
@@ -54,18 +57,28 @@ struct Balloon: View {
                     Image(rightIcon)
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 16, height: 16)
+                        .frame(
+                            width: 16,
+                            height: 16
+                        )
                 }
                 
                 Spacer()
             }
-            .padding(.vertical, 8)
+            .padding(
+                .vertical,
+                8
+            )
             .frame(maxWidth: .infinity)
             .background(
                 RoundedRectangle(cornerRadius: 20)
                     .fill(Color(.staticWhite))
             )
-            .shadow(color: Color(.staticBlack).opacity(0.25), radius: 4, y: 4)
+            .shadow(
+                color: Color(.staticBlack).opacity(0.25),
+                radius: 4,
+                y: 4
+            )
             
             if balloonMode == .bottom {
                 bottomBalloonTip
@@ -78,7 +91,10 @@ struct Balloon: View {
             Image(.balloonTip)
                 .renderingMode(.template)
                 .foregroundStyle(Color(.staticWhite))
-                .padding(.leading, 24)
+                .padding(
+                    .leading,
+                    24
+                )
             
             Spacer()
         }
@@ -89,7 +105,10 @@ struct Balloon: View {
             Image(.balloonTip)
                 .renderingMode(.template)
                 .foregroundStyle(Color(.staticWhite))
-                .padding(.leading, 24)
+                .padding(
+                    .leading,
+                    24
+                )
             
             Spacer()
         }
@@ -99,6 +118,11 @@ struct Balloon: View {
 }
 
 #Preview {
-    Balloon(text: "사장님의 과제 빵점 탈출을 응원해요!", leftIcon: "bubble", rightIcon: "bubble", balloonMode: .bottom)
-        .padding(.horizontal, 20)
+    Balloon(
+        text: "사장님의 과제 빵점 탈출을 응원해요!",
+        leftIcon: "bubble",
+        rightIcon: "bubble",
+        balloonMode: .bottom
+    )
+    .padding(.horizontal, 20)
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CircleIcon.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CircleIcon.swift
@@ -19,7 +19,10 @@ struct CircleIcon: View {
         GeometryReader { geometry in
             ZStack {
                 Circle()
-                    .stroke(Color(.lineNormal), lineWidth: 1)
+                    .stroke(
+                        Color(.lineNormal),
+                        lineWidth: 1
+                    )
                 
                 Image(name)
                     .resizable()
@@ -27,6 +30,9 @@ struct CircleIcon: View {
                     .padding(geometry.size.width * 0.25)
             }
         }
-        .aspectRatio(1, contentMode: .fit)
+        .aspectRatio(
+            1,
+            contentMode: .fit
+        )
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
@@ -53,24 +53,36 @@ struct Homies: View {
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 24)
-                        .stroke(state.borderColor, lineWidth: 3)
+                        .stroke(
+                            state.borderColor,
+                            lineWidth: 3
+                        )
                 )
         }
     
     var body: some View {
         HStack(spacing: 0) {
             profile
-                .padding(.trailing, 16)
+                .padding(
+                    .trailing,
+                    16
+                )
             
             friendName
             
             Spacer()
             
             Image(.dotsVertical)
-                .padding(.horizontal, 10)
+                .padding(
+                    .horizontal,
+                    10
+                )
         }
         .frame(maxWidth: .infinity)
-        .padding(.all, 16)
+        .padding(
+            .all,
+            16
+        )
         .background(backgroundView)
     }
 }
@@ -85,7 +97,10 @@ struct Homies: View {
             ),
             name: "강라리"
         )
-        .padding(.horizontal, 20)
+        .padding(
+            .horizontal,
+            20
+        )
         
         Homies(
             state: .checked,
@@ -95,7 +110,10 @@ struct Homies: View {
             ),
             name: "강라리"
         )
-        .padding(.horizontal, 20)
+        .padding(
+            .horizontal,
+            20
+        )
         
         Homies(
             state: .holding,
@@ -105,6 +123,9 @@ struct Homies: View {
             ),
             name: "강라리"
         )
-        .padding(.horizontal, 20)
+        .padding(
+            .horizontal,
+            20
+        )
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
@@ -1,0 +1,105 @@
+//
+//  Homies.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 1/16/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct Homies: View {
+    private let state: HomiesState
+    private let profile: SingleProfile
+    private let name: String
+    
+    init(
+        state: HomiesState,
+        profile: SingleProfile,
+        name: String
+    ) {
+        self.state = state
+        self.profile = profile
+        self.name = name
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            profile
+                .padding(.trailing, 16)
+            
+            HStack(spacing: 3.2) {
+                CustomText(
+                    name,
+                    fontType: .headline1Bold,
+                    color: Color(
+                        .labelNormal
+                    )
+                )
+                
+                CustomText(
+                    "사장님",
+                    fontType: .caption2Bold,
+                    color: Color(
+                        .labelAlternative
+                    )
+                )
+            }
+            
+            Spacer()
+            
+            Image(.dotsVertical)
+                .padding(.horizontal, 10)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.all, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .fill(state == HomiesState.basic ? Color(.backgroundNormal)
+                      : Color(.backgroundAlternative))
+                .shadow(
+                    color: Color(.staticBlack).opacity(0.25),
+                    radius: 4,
+                    y: 4
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24)
+                        .stroke(state == HomiesState.checked ? Color(.lineStrong) : Color.clear, lineWidth: 3)
+                )
+        )
+    }
+}
+
+#Preview {
+    VStack(spacing: 50) {
+        Homies(
+            state: .basic,
+            profile: SingleProfile(
+                size: .medium,
+                outlined: true
+            ),
+            name: "강라리"
+        )
+        .padding(.horizontal, 20)
+        
+        Homies(
+            state: .checked,
+            profile: SingleProfile(
+                size: .medium,
+                outlined: true
+            ),
+            name: "강라리"
+        )
+        .padding(.horizontal, 20)
+        
+        Homies(
+            state: .holding,
+            profile: SingleProfile(
+                size: .medium,
+                outlined: true
+            ),
+            name: "강라리"
+        )
+        .padding(.horizontal, 20)
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
@@ -23,28 +23,46 @@ struct Homies: View {
         self.name = name
     }
     
+    private var friendName: some View {
+        HStack(spacing: 3.2) {
+            CustomText(
+                name,
+                fontType: .headline1Bold,
+                color: Color(
+                    .labelNormal
+                )
+            )
+            
+            CustomText(
+                "사장님",
+                fontType: .caption2Bold,
+                color: Color(
+                    .labelAlternative
+                )
+            )
+        }
+    }
+    
+    private var backgroundView: some View {
+            RoundedRectangle(cornerRadius: 24)
+                .fill(state.backgroundColor)
+                .shadow(
+                    color: Color(.staticBlack).opacity(0.25),
+                    radius: 4,
+                    y: 4
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24)
+                        .stroke(state.borderColor, lineWidth: 3)
+                )
+        }
+    
     var body: some View {
         HStack(spacing: 0) {
             profile
                 .padding(.trailing, 16)
             
-            HStack(spacing: 3.2) {
-                CustomText(
-                    name,
-                    fontType: .headline1Bold,
-                    color: Color(
-                        .labelNormal
-                    )
-                )
-                
-                CustomText(
-                    "사장님",
-                    fontType: .caption2Bold,
-                    color: Color(
-                        .labelAlternative
-                    )
-                )
-            }
+            friendName
             
             Spacer()
             
@@ -53,20 +71,7 @@ struct Homies: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.all, 16)
-        .background(
-            RoundedRectangle(cornerRadius: 24)
-                .fill(state == HomiesState.basic ? Color(.backgroundNormal)
-                      : Color(.backgroundAlternative))
-                .shadow(
-                    color: Color(.staticBlack).opacity(0.25),
-                    radius: 4,
-                    y: 4
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 24)
-                        .stroke(state == HomiesState.checked ? Color(.lineStrong) : Color.clear, lineWidth: 3)
-                )
-        )
+        .background(backgroundView)
     }
 }
 

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
@@ -54,17 +54,13 @@ struct Homies: View {
             CustomText(
                 name,
                 fontType: .headline1Bold,
-                color: Color(
-                    .labelNormal
-                )
+                color: Color(.labelNormal)
             )
             
             CustomText(
                 "사장님",
                 fontType: .caption2Bold,
-                color: Color(
-                    .labelAlternative
-                )
+                color: Color(.labelAlternative)
             )
         }
     }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Homies.swift
@@ -23,43 +23,6 @@ struct Homies: View {
         self.name = name
     }
     
-    private var friendName: some View {
-        HStack(spacing: 3.2) {
-            CustomText(
-                name,
-                fontType: .headline1Bold,
-                color: Color(
-                    .labelNormal
-                )
-            )
-            
-            CustomText(
-                "사장님",
-                fontType: .caption2Bold,
-                color: Color(
-                    .labelAlternative
-                )
-            )
-        }
-    }
-    
-    private var backgroundView: some View {
-            RoundedRectangle(cornerRadius: 24)
-                .fill(state.backgroundColor)
-                .shadow(
-                    color: Color(.staticBlack).opacity(0.25),
-                    radius: 4,
-                    y: 4
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 24)
-                        .stroke(
-                            state.borderColor,
-                            lineWidth: 3
-                        )
-                )
-        }
-    
     var body: some View {
         HStack(spacing: 0) {
             profile
@@ -84,6 +47,43 @@ struct Homies: View {
             16
         )
         .background(backgroundView)
+    }
+    
+    private var friendName: some View {
+        HStack(spacing: 3.2) {
+            CustomText(
+                name,
+                fontType: .headline1Bold,
+                color: Color(
+                    .labelNormal
+                )
+            )
+            
+            CustomText(
+                "사장님",
+                fontType: .caption2Bold,
+                color: Color(
+                    .labelAlternative
+                )
+            )
+        }
+    }
+    
+    private var backgroundView: some View {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(state.backgroundColor)
+            .shadow(
+                color: Color(.staticBlack).opacity(0.25),
+                radius: 4,
+                y: 4
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .stroke(
+                        state.borderColor,
+                        lineWidth: 3
+                    )
+            )
     }
 }
 

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/HomiesState.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/HomiesState.swift
@@ -12,4 +12,22 @@ enum HomiesState {
     case basic
     case checked
     case holding
+    
+    var backgroundColor: Color {
+        switch self {
+        case .basic:
+            return Color(.backgroundNormal)
+        case .checked, .holding:
+            return Color(.backgroundAlternative)
+        }
+    }
+
+    var borderColor: Color {
+        switch self {
+        case .checked:
+            return Color(.lineStrong)
+        default:
+            return Color.clear
+        }
+    }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/HomiesState.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/HomiesState.swift
@@ -1,0 +1,15 @@
+//
+//  HomiesState.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 1/16/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+enum HomiesState {
+    case basic
+    case checked
+    case holding
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/HomiesState.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/HomiesState.swift
@@ -16,18 +16,18 @@ enum HomiesState {
     var backgroundColor: Color {
         switch self {
         case .basic:
-            return Color(.backgroundNormal)
+            Color(.backgroundNormal)
         case .checked, .holding:
-            return Color(.backgroundAlternative)
+            Color(.backgroundAlternative)
         }
     }
 
     var borderColor: Color {
         switch self {
         case .checked:
-            return Color(.lineStrong)
+            Color(.lineStrong)
         default:
-            return Color.clear
+            Color.clear
         }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Pagination.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Pagination.swift
@@ -24,7 +24,7 @@ struct Pagination: View {
                 id: \.self
             ) { index in
                 Circle()
-                    .fill(index == current ? Color(.materialDimmer) : Color(.materialDimmer).opacity(0.16))
+                    .fill(Color(.materialDimmer).opacity(index == current ? 1 : 0.16))
                     .frame(
                         width: 6,
                         height: 6

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Pagination.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Pagination.swift
@@ -19,16 +19,28 @@ struct Pagination: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(1..<total+1, id: \.self) { index in
+            ForEach(
+                1..<total+1,
+                id: \.self
+            ) { index in
                 Circle()
                     .fill(index == current ? Color(.materialDimmer) : Color(.materialDimmer).opacity(0.16))
-                    .frame(width: 6, height: 6)
-                    .padding(.trailing, index == total ? 0 : 8)
+                    .frame(
+                        width: 6,
+                        height: 6
+                    )
+                    .padding(
+                        .trailing,
+                        index == total ? 0 : 8
+                    )
             }
         }
     }
 }
 
 #Preview {
-    Pagination(totalPage: 4, nowPage: 1)
+    Pagination(
+        totalPage: 4,
+        nowPage: 1
+    )
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/SingleProfile.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/SingleProfile.swift
@@ -41,9 +41,21 @@ struct SingleProfile: View {
 
 #Preview {
     HStack {
-        SingleProfile(size: .large, outlined: true)
-        SingleProfile(size: .large, outlined: false)
-        SingleProfile(size: .medium, outlined: true)
-        SingleProfile(size: .medium, outlined: false)
+        SingleProfile(
+            size: .large,
+            outlined: true
+        )
+        SingleProfile(
+            size: .large,
+            outlined: false
+        )
+        SingleProfile(
+            size: .medium,
+            outlined: true
+        )
+        SingleProfile(
+            size: .medium,
+            outlined: false
+        )
     }
 }


### PR DESCRIPTION
## 🥖 What is the PR?

친구 목록에서 사용하는 Homies 컴포넌트를 구현하였습니다.

## 🥐 Changes

- Single Profile과 이름이 뜨는 카드 구현
- Basic, Checked, Holding 상태에 따른 분기 처리
- 카드 배경 색상과 테두리로 구분

## 🥯 Thoughts

- 테두리 색상 lineStrong이 잘못 적용되어 있지만 develop에 머지하면 해결 될 예정!
- 피그마에는 Default, Checked, PlaceHolder로 네이밍 되어 있는데 default 키워드와 겹치고, placeholder는 직관적이지 않은 네이밍 같아서 임의로 Basic, Checked, Holding으로 수정하였습니다. 괜찮을까요?
- Balloon 만들 때 유빈오빠에게 배운 방식을 똑같이 적용해 보았습니다.

## 🥪 Screenshot

![image](https://github.com/user-attachments/assets/baf48853-3bbb-427a-964d-1514d0a3d299)

## 🥨 To Reviewers

사용 예시는 아래와 같습니다.
```
Homies(
            state: .basic,
            profile: SingleProfile(
                size: .medium,
                outlined: true
            ),
            name: "강라리"
        )
        .padding(.horizontal, 20)
```

## 🍞 Related Issues

- #29
