### PR TITLE
[Feature] 과목 입력 레이아웃 구현

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Font/CustomFont.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Font/CustomFont.swift
@@ -112,31 +112,31 @@ enum CustomFont: Sendable {
     var letterSpacing: CGFloat {
         switch self {
         case .title1Small, .title1Medium, .title1Bold:
-            return -0.027
+            return -0.972
         case .title2Small, .title2Medium, .title2Bold:
-            return -0.0236
+            return -0.6608
         case .title3Small, .title3Medium, .title3Bold:
-            return -0.023
+            return -0.552
         case .heading1Small, .heading1Medium, .heading1Bold:
-            return -0.0194
+            return -0.4268
         case .heading2Small, .heading2Medium, .heading2Bold:
-            return -0.012
+            return -0.24
         case .headline1Small, .headline1Medium, .headline1Bold:
-            return -0.002
+            return -0.0036
         case .headline2Small, .headline2Medium, .headline2Bold:
             return 0
         case .body1Small, .body1Medium, .body1Bold:
-            return 0.0057
+            return 0.0912
         case .body2Small, .body2Medium, .body2Bold:
-            return 0.0096
+            return 0.144
         case .label1Small, .label1Medium, .label1Bold:
-            return 0.0145
+            return 0.203
         case .label2Small, .label2Medium, .label2Bold:
-            return 0.0194
+            return 0.2522
         case .caption1Small, .caption1Medium, .caption1Bold:
-            return 0.0252
+            return 0.3024
         case .caption2Small, .caption2Medium, .caption2Bold:
-            return 0.0311
+            return 0.3421
         }
     }
 

--- a/BBANGZIP/BBANGZIP/Sources/Font/CustomFont.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Font/CustomFont.swift
@@ -163,7 +163,7 @@ struct FontModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(font.swiftUIFont)
-            .lineSpacing(font.lineHeight - font.size)
+            .lineSpacing((font.lineHeight - font.size) / 4)
             .kerning(font.letterSpacing)
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/ProgressBar.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/ProgressBar.swift
@@ -15,22 +15,22 @@ struct ProgressBar: View {
         ProgressView(value: category.percentage) {            
             HStack {
                 StepCircle(
-                    step: category,
+                    step: Step.first,
                     complete: true
                 )
                 
                 Spacer()
                 
                 StepCircle(
-                    step: category,
-                    complete: category != .First
+                    step: Step.second,
+                    complete: category != .first
                 )
                 
                 Spacer()
                 
                 StepCircle(
-                    step: category,
-                    complete: category == .Third
+                    step: Step.third,
+                    complete: category == .third
                 )
             }
             .padding(
@@ -38,6 +38,8 @@ struct ProgressBar: View {
                 8
             )
         }
-        .progressViewStyle(LinearProgressViewStyle(tint: Color(.statusPositive)))
+        .progressViewStyle(
+            LinearProgressViewStyle(tint: Color(.statusPositive))
+        )
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Step.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Step.swift
@@ -9,17 +9,17 @@
 import SwiftUI
 
 enum Step: Int {
-    case First = 1
-    case Second = 2
-    case Third = 3
+    case first = 1
+    case second = 2
+    case third = 3
     
     var percentage: CGFloat {
         switch self {
-        case .First:
+        case .first:
             0.04
-        case .Second:
+        case .second:
             0.5
-        case .Third:
+        case .third:
             1
         }
     }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
@@ -9,17 +9,32 @@
 import SwiftUI
 
 struct SubjectInputView: View {
-    @State private var currentStep: Step = .third
-    @State private var subject: String = ""
-    @State private var selectedYear: Int = 2025
-    @State private var selectedSemester: String = "1학기"
-    @State private var announceState: NicknameTextFieldAlertCase? = nil
-    @State private var state: TextFieldState = .defaultState
+    @State private var currentStep: Step
+    @State private var subject: String
+    @State private var selectedYear: Int
+    @State private var selectedSemester: Semester
+    @State private var announceState: NicknameTextFieldAlertCase?
+    @State private var state: TextFieldState
+    
+    init(
+        // TODO: 부모 뷰에서 공통적으로 사용할 currentStep은 삭제 필요
+        currentStep: Step = .third,
+        subject: String,
+        selectedYear: Int,
+        selectedSemester: Semester,
+        announceState: NicknameTextFieldAlertCase? = nil,
+        state: TextFieldState = .defaultState
+    ) {
+        self.currentStep = currentStep
+        self.subject = subject
+        self.selectedYear = selectedYear
+        self.selectedSemester = selectedSemester
+        self.announceState = announceState
+        self.state = state
+    }
     
     var body: some View {
         VStack(spacing: 0) {
-            backButton
-            
             ProgressBar(category: $currentStep)
                 .padding(
                     .horizontal,
@@ -46,10 +61,18 @@ struct SubjectInputView: View {
                 20
             )
         }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarLeading) {
+                backButton
+            }
+        }
     }
     
     private var backButton: some View {
-        HStack(spacing: 0) {
+        Button(action: {
+            // TODO: 뒤로가기 버튼 누르면 상태 변경하도록
+        }) {
             Image(.chevronLeftThickSmall)
                 .renderingMode(.template)
                 .foregroundStyle(Color(.labelAlternative))
@@ -120,5 +143,9 @@ struct SubjectInputView: View {
 }
 
 #Preview {
-    SubjectInputView()
+    SubjectInputView(
+        subject: "경제학원론",
+        selectedYear: 2025,
+        selectedSemester: Semester.summer
+    )
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
@@ -95,6 +95,7 @@ struct SubjectInputView: View {
                     fontType: .title2Bold,
                     color: Color(.labelNormal)
                 )
+                Spacer()
             }
             .padding(
                 .bottom,

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
@@ -112,7 +112,7 @@ struct SubjectInputView: View {
         }
         .buttonStyle(
             SolidIconButton(
-                buttonImage: Image(.chevronLeftThickSmall)
+                buttonImage: Image(.chevronRight)
             )
         )
         

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct SubjectInputView: View {
-    @State private var currentStep: Step = .Third
+    @State private var currentStep: Step = .third
     @State private var subject: String = ""
     @State private var selectedYear: Int = 2025
     @State private var selectedSemester: String = "1학기"
@@ -78,20 +78,7 @@ struct SubjectInputView: View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 CustomText(
-                    "수강하는 과목 중",
-                    fontType: .title2Bold,
-                    color: Color(.labelNormal)
-                )
-                Spacer()
-            }
-            .padding(
-                .bottom,
-                5
-            )
-            
-            HStack(spacing: 0) {
-                CustomText(
-                    "한 가지만 먼저 입력해 볼까요?",
+                    "수강하는 과목 중\n한 가지만 먼저 입력해 볼까요?",
                     fontType: .title2Bold,
                     color: Color(.labelNormal)
                 )

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
@@ -75,19 +75,32 @@ struct SubjectInputView: View {
     }
     
     private var mainDescription: some View {
-        HStack(spacing: 0) {
-            CustomText(
-                "수강하는 과목 중\n한 가지만 먼저 입력해 볼까요?",
-                fontType: .title2Bold,
-                color: Color(.labelNormal)
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                CustomText(
+                    "수강하는 과목 중",
+                    fontType: .title2Bold,
+                    color: Color(.labelNormal)
+                )
+                Spacer()
+            }
+            .padding(
+                .bottom,
+                5
             )
             
-            Spacer()
+            HStack(spacing: 0) {
+                CustomText(
+                    "한 가지만 먼저 입력해 볼까요?",
+                    fontType: .title2Bold,
+                    color: Color(.labelNormal)
+                )
+            }
+            .padding(
+                .bottom,
+                33
+            )
         }
-        .padding(
-            .bottom,
-            33
-        )
     }
     
     private var subjectTextField: some View {

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/SubjectInputView.swift
@@ -1,0 +1,123 @@
+//
+//  SubjectInputView.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 1/18/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct SubjectInputView: View {
+    @State private var currentStep: Step = .Third
+    @State private var subject: String = ""
+    @State private var selectedYear: Int = 2025
+    @State private var selectedSemester: String = "1학기"
+    @State private var announceState: NicknameTextFieldAlertCase? = nil
+    @State private var state: TextFieldState = .defaultState
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            backButton
+            
+            ProgressBar(category: $currentStep)
+                .padding(
+                    .horizontal,
+                    44
+                )
+                .padding(
+                    .bottom,
+                    48
+                )
+            
+            VStack(spacing: 0) {
+                headerDescription
+                
+                mainDescription
+                
+                subjectTextField
+                
+                Spacer()
+                
+                nextButton
+            }
+            .padding(
+                .horizontal,
+                20
+            )
+        }
+    }
+    
+    private var backButton: some View {
+        HStack(spacing: 0) {
+            Image(.chevronLeftThickSmall)
+                .renderingMode(.template)
+                .foregroundStyle(Color(.labelAlternative))
+            Spacer()
+        }
+        .padding(16)
+    }
+    
+    private var headerDescription: some View {
+        HStack(spacing: 0) {
+            CustomText(
+                "\(selectedYear)년 \(selectedSemester)에 재학 중이시네요!",
+                fontType: .body2Bold,
+                color: Color(.labelAlternative)
+            )
+            
+            Spacer()
+        }
+        .padding(
+            .bottom,
+            8
+        )
+    }
+    
+    private var mainDescription: some View {
+        HStack(spacing: 0) {
+            CustomText(
+                "수강하는 과목 중\n한 가지만 먼저 입력해 볼까요?",
+                fontType: .title2Bold,
+                color: Color(.labelNormal)
+            )
+            
+            Spacer()
+        }
+        .padding(
+            .bottom,
+            33
+        )
+    }
+    
+    private var subjectTextField: some View {
+        TextField(
+            "예) 유나대장",
+            text: $subject
+        )
+        .textFieldStyle(
+            CustomTextFieldStyle(
+                text: $subject,
+                style: .nickname,
+                state: state,
+                alertText: announceState
+            )
+        )
+    }
+    
+    private var nextButton: some View {
+        NavigationLink("다음으로") {
+            // TODO: 다음 버튼 입력 시 화면 전환 필요
+        }
+        .buttonStyle(
+            SolidIconButton(
+                buttonImage: Image(.chevronLeftThickSmall)
+            )
+        )
+        
+    }
+}
+
+#Preview {
+    SubjectInputView()
+}


### PR DESCRIPTION
## 🥖 What is the PR?

온보딩 단계에서 과목을 입력받는 레이아웃을 구현하였습니다.

## 🥐 Changes

- 과목 입력 레이아웃 구현
- 자간 설정 시 kerning()에 em 단위가 아닌 pixel 단위로 입력하도록 수정
- toolBar 커스텀하여 뒤로가기 버튼 구현

## 🥯 Thoughts

- 자간이 안 맞아서 한 줄짜리 텍스트가 줄바꿈되어 두 줄로 되는 바람에 고생 꽤나 했습니다. kerning()에는 em 단위가 아닌 pixel 단위를 입력하여야 한다는 것을 배웠습니다.
- TextField 로직 수정 필요합니다.
- 온보딩 뷰 전체 연결 시 backButton과 nextButton의 action 로직 수정 필요합니다.

## 🥪 Screenshot

<img src="https://github.com/user-attachments/assets/73fdc1f4-1a12-4c80-ad5c-6d452f3e06a4" width="300">

## 🍞 Related Issues

- #51
