### PR TITLE
[Feature] 나누어 공부하기 바텀시트 레이아웃 구현

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/BottomSheetType.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/BottomSheetType.swift
@@ -17,6 +17,7 @@ enum BottomSheetType: Int {
     case examDate
     case studyFinishDate
     case changeSemester
+    case divideStudy
     
     @MainActor @ViewBuilder
     func contentView(isPresented: Binding<Bool>) -> some View {
@@ -54,6 +55,10 @@ enum BottomSheetType: Int {
                 isPresented: isPresented,
                 selectedYear: .constant(2025),
                 selectedSemester: .constant("1학기")
+            )
+        case .divideStudy:
+            DivideStudyBottomSheet(
+                isPresented: isPresented
             )
         default:
             Text("아직 구현되지 않은 뷰입니다.")

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/DivideStudyBottomSheet.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/DivideStudyBottomSheet.swift
@@ -1,0 +1,55 @@
+//
+//  DivideBottomSheet.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 1/19/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct DivideStudyBottomSheet: View {
+    @Binding private var isPresented: Bool
+    
+    private let pieces = Array(1...6)
+    
+    init(isPresented: Binding<Bool>) {
+        self._isPresented = isPresented
+    }
+    
+    var body: some View {
+        CustomText(
+            "몇 조각으로 쪼개서 공부할까요?",
+            fontType: .headline1Bold,
+            color: Color(.labelNeutral)
+        )
+        .padding(
+            .vertical,
+            39
+        )
+        
+        VStack {
+            ForEach(pieces, id: \.self) { num in
+                CustomText(
+                    "\(num)조각",
+                    fontType: .body1Bold,
+                    color: Color(.labelNormal)
+                )
+                .padding(
+                    .vertical,
+                    8
+                )
+            }
+        }
+        .padding(
+            .bottom,
+            24
+        )
+    }
+}
+
+#Preview {
+    let isPresented = Binding.constant(true)
+    
+    DivideStudyBottomSheet(isPresented: isPresented)
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/DivideStudyView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/DivideStudyView.swift
@@ -1,0 +1,35 @@
+//
+//  DivideStudyView.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 1/19/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct DivideStudyView: View {
+    @State private var isBottomSheetPresented = true
+    @State private var selectedBottomSheetType: BottomSheetType? = .divideStudy
+    
+    var body: some View {
+        VStack {
+            Button("공부 내용 등록하기") {
+                selectedBottomSheetType = .divideStudy
+                isBottomSheetPresented = true
+            }
+        }
+        .bottomSheet(
+            isShowing: $isBottomSheetPresented,
+            height: 449) {
+                if let type = selectedBottomSheetType {
+                    type.contentView(isPresented: $isBottomSheetPresented)
+                }
+            }
+    }
+}
+
+#Preview {
+    DivideStudyView()
+}
+


### PR DESCRIPTION
## 🥖 What is the PR?

나누어 공부하기 바텀시트를 구현하였습니다.

## 🥐 Changes

- 바텀시트 안에 들어갈 DivideStudyBottomSheet 구현
- 실제 바텀시트를 불러오는 예시 뷰인 DivideStudyView 구현

## 🥯 Thoughts

- 공부 추가하기 뷰에서 버튼을 누르면 해당 바텀시트가 올라와야하기 때문에, 추후 공부 추가하기 뷰 구현 후 DivideStudyView를 삭제하고 바텀시트 연결하는 로직을 추가해줘야 할 것 같습니다.

## 🥪 Screenshot

<img src="https://github.com/user-attachments/assets/65b60a6b-8bfb-4f0b-b36f-ae41fb0ce717" width="300">

## 🍞 Related Issues

- #60
