### PR TITLE
[Feature] 과목 내 동기부여 메시지 추가 화면 레이아웃 구현

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
@@ -10,12 +10,17 @@ import SwiftUI
 
 struct CustomNavigationBar: View {
     @SwiftUI.Environment(\.dismiss) var dismiss
-    let showBackButton: Bool
-    let showMenu: Bool
-    let title: String
-    let backgroundColor: Color?
+    private let showBackButton: Bool
+    private let showMenu: Bool
+    private let title: String
+    private let backgroundColor: Color?
     
-    init(showBackButton: Bool, showMenu: Bool, title: String, backgroundColor: Color) {
+    init(
+        showBackButton: Bool,
+        showMenu: Bool,
+        title: String,
+        backgroundColor: Color
+    ) {
         self.showBackButton = showBackButton
         self.showMenu = showMenu
         self.title = title
@@ -87,7 +92,7 @@ extension CustomNavigationBar {
     private var kebabButton: some View {
         // TODO: custom으로 수정 필요
         Menu {
-            NavigationLink(destination: Text("첫 번째 화면")) {
+            NavigationLink(destination: AddMotivationMessageView()) {
                 CustomText(
                     "각오 한 마디 작성하기",
                     fontType: .body1Bold,

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/TextField/AlertCase/MessageTextFieldAlertCase.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/TextField/AlertCase/MessageTextFieldAlertCase.swift
@@ -1,0 +1,21 @@
+//
+//  MessageTextFieldAlertCase.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/22/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+enum MessageTextFieldAlertCase: TextFieldAlertable {
+    case alert
+    case enable
+    
+    var alertText: String {
+        switch self {
+        case .alert:
+            "한글/영문/숫자/기호 조합으로 최대 25자까지 입력 가능해요."
+        case .enable:
+            ""
+        }
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/TextField/TextFieldStyleCase.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/TextField/TextFieldStyleCase.swift
@@ -14,6 +14,7 @@ enum TextFieldStyleCase {
     case studyContent
     case studyRange
     case subject
+    case message
     
     var icon: Image? {
         switch self {
@@ -27,6 +28,8 @@ enum TextFieldStyleCase {
             Image(.checkSmall)
         case .subject:
             Image(.book)
+        case .message:
+            Image(.bubble)
         }
     }
     
@@ -40,12 +43,14 @@ enum TextFieldStyleCase {
             20
         case .subject:
             10
+        case .message:
+            25
         }
     }
     
     var clearable: Bool {
         switch self {
-        case .nickname, .subject:
+        case .nickname, .subject, .message:
             true
         case .date, .studyContent, .studyRange:
             false

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Extension/HideKeyboard.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Extension/HideKeyboard.swift
@@ -1,0 +1,21 @@
+//
+//  HideKeyboard.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 1/20/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    func hideKeyboard() {
+        let resign = #selector(UIResponder.resignFirstResponder)
+        UIApplication.shared.sendAction(
+            resign,
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Extension/String+Contains.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Extension/String+Contains.swift
@@ -20,4 +20,14 @@ extension String {
             options: .regularExpression
         ) != nil
     }
+    
+    var isMessageValid: Bool {
+        let trimmedText = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        let regex = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\\s!@#$%^&*(),.?\":{}|<>]{1,25}$"
+        
+        return !trimmedText.isEmpty && trimmedText.range(
+            of: regex,
+            options: .regularExpression
+        ) != nil
+    }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
@@ -1,0 +1,112 @@
+//
+//  MotivationMessageView.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/22/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct AddMotivationMessageView: View {
+    @StateObject private var viewModel: AddMotivationMessageViewModel
+    @FocusState private var isMessageFocused: Bool
+    
+    init(viewModel: AddMotivationMessageViewModel = AddMotivationMessageViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+    
+    var body: some View {
+        ZStack {
+            Color(.clear)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    hideKeyboard()
+                }
+            
+            VStack {
+                CustomNavigationBar(
+                    showBackButton: true,
+                    showMenu: false,
+                    title: "각오 한 마디 작성하기",
+                    backgroundColor: Color(.backgroundNormal)
+                )
+                
+                inputSection
+                    .padding(
+                        .top,
+                        48
+                    )
+                    .padding(
+                        .horizontal,
+                        20
+                    )
+                
+                Spacer()
+            }
+            
+            VStack {
+                Spacer()
+                
+                Button("등록하기") {
+                    print("click")
+                }
+                .buttonStyle(SolidButton(viewModel.isButtonEnabled))
+                .disabled(!viewModel.isButtonEnabled)
+                .padding(
+                    .bottom,
+                    36
+                )
+            }
+            .padding(.horizontal, 20)
+            .ignoresSafeArea(edges: .bottom)
+        }
+        .navigationBarHidden(true)
+    }
+    
+    var inputSection: some View {
+        VStack(spacing: 16){
+            HStack {
+                CustomText(
+                    "사장님의 각오 한 마디를\n작성해 보세요",
+                    fontType: .headline1Bold
+                )
+                
+                Spacer()
+            }
+            
+            TextField(
+                "예) 이번엔 열심히 공부해서 빵점 탈출!",
+                text: $viewModel.message
+            )
+            .textFieldStyle(
+                CustomTextFieldStyle(
+                    text: $viewModel.message,
+                    style: .message,
+                    state: viewModel.messageState,
+                    alertText: viewModel.messageAnnounceState
+                )
+            )
+            .onChange(of: viewModel.message) { newMessage in
+                if newMessage.count > 25 {
+                    viewModel.message = String(newMessage.prefix(25))
+                }
+                
+                viewModel.verifyMessage(
+                    newText: newMessage,
+                    isMessageFocused: isMessageFocused
+                )
+            }
+            .onChange(of: isMessageFocused) { isMessageFocused in
+                viewModel.handleMessageFocusChange(
+                    newText: viewModel.message,
+                    isMessageFocused: isMessageFocused
+                )
+            }
+        }
+    }
+}
+
+#Preview {
+    AddMotivationMessageView()
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
@@ -12,7 +12,9 @@ struct AddMotivationMessageView: View {
     @StateObject private var viewModel: AddMotivationMessageViewModel
     @FocusState private var isMessageFocused: Bool
     
-    init(viewModel: AddMotivationMessageViewModel = AddMotivationMessageViewModel()) {
+    init(
+        viewModel: AddMotivationMessageViewModel = AddMotivationMessageViewModel()
+    ) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
     
@@ -105,8 +107,4 @@ struct AddMotivationMessageView: View {
             }
         }
     }
-}
-
-#Preview {
-    AddMotivationMessageView()
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct AddMotivationMessageView: View {
+    @SwiftUI.Environment(\.dismiss) var dismiss
     @StateObject private var viewModel: AddMotivationMessageViewModel
     @FocusState private var isMessageFocused: Bool
     
@@ -52,6 +53,8 @@ struct AddMotivationMessageView: View {
                 
                 Button("등록하기") {
                     print("click")
+                    viewModel.changeMotivationMessage()
+                    dismiss()
                 }
                 .buttonStyle(SolidButton(viewModel.isButtonEnabled))
                 .disabled(!viewModel.isButtonEnabled)

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageViewModel.swift
@@ -74,4 +74,8 @@ final class AddMotivationMessageViewModel: ObservableObject {
         
         isButtonEnabled = messageAnnounceState == .enable
     }
+    
+    func changeMotivationMessage() {
+        // TODO: 동기부여 메시지 작성 및 수정 API 연동 필요
+    }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageViewModel.swift
@@ -1,0 +1,77 @@
+//
+//  AddMotivationMessageViewModel.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/22/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+final class AddMotivationMessageViewModel: ObservableObject {
+    @Published var message: String
+    @Published var messageAnnounceState: MessageTextFieldAlertCase?
+    @Published var messageState: TextFieldState
+    @Published var isMessageFocused: Bool = false
+    @Published var isMessageValid: Bool = false
+    @Published var isButtonEnabled: Bool = false
+    
+    init(
+        message: String = "",
+        messageAnnounceState: MessageTextFieldAlertCase? = .alert,
+        messageState: TextFieldState = .defaultState,
+        isMessageFocused: Bool = false,
+        isMessageValid: Bool = false
+    ) {
+        self.message = message
+        self.messageAnnounceState = messageAnnounceState
+        self.messageState = messageState
+        self.isMessageFocused = isMessageFocused
+        self.isMessageValid = isMessageValid
+    }
+    
+    func verifyMessage(
+        newText: String,
+        isMessageFocused: Bool
+    ) {
+        validateMessageState(
+            newText: newText,
+            isMessageFocused: isMessageFocused
+        )
+    }
+    
+    func handleMessageFocusChange(
+        newText: String,
+        isMessageFocused: Bool
+    ) {
+        validateMessageState(
+            newText: newText,
+            isMessageFocused: isMessageFocused
+        )
+    }
+    
+    private func validateMessageState(
+        newText: String,
+        isMessageFocused: Bool
+    ) {
+        if !isMessageFocused {
+            if newText.isEmpty {
+                messageState = .defaultState  // 추가
+                isMessageValid = false
+            } else if newText.isMessageValid {
+                messageState = .field
+                messageAnnounceState = .enable
+                isMessageValid = true
+            } else {
+                messageState = .alert
+                messageAnnounceState = .alert
+                isMessageValid = false
+            }
+        } else {
+            messageState = .placeholder
+            isMessageValid = false
+        }
+        
+        isButtonEnabled = messageAnnounceState == .enable
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageView.swift
@@ -95,6 +95,7 @@ struct SubjectManageView: View {
             }
             .onAppear {
                 viewModel.fetchSubjectData()
+                isCustomTabBarHidden = false
             }
         }
         .edgesIgnoringSafeArea(.top)
@@ -150,7 +151,6 @@ struct SubjectManageView: View {
                 
                 NavigationLink(destination: SubjectDetailView(viewModel: SubjectDetailViewModel(modelList: StudyPieceModel.mockList), isBottomSheetShowing: $isBottomSheetShowing)
                     .onAppear { isCustomTabBarHidden = true }
-                    .onDisappear { isCustomTabBarHidden = false }
                 ) {
                     SubjectCard(
                         state: model.state,


### PR DESCRIPTION
## 🥖 What is the PR?

- 과목 내 동기부여 메시지 추가 화면을 구현하였습니다.

## 🥐 Changes

- MessageTextField를 구현
- AddMotivationVIew, VIewModel 구현 

## 🥯 Thoughts

- 화면 구현 시 로직을 간단히 하기 위해 고민했습니다.
- customTabBar을 숨기기 위해서 .onAppear을 이용하였습니다.

## 🥪 Screenshot

| 과목 추가 화면 1 | 과목 추가 화면 2|
| --- | --- |
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/4b1e9dc4-a189-4307-848b-00d1155258d8" /> | <img width="324" alt="image" src="https://github.com/user-attachments/assets/0c64efdd-e72e-4da1-bdb7-b284e73ef2c1" /> |

## 🥨 To Reviewers

isCustomTabBar를 탭뷰에 바인딩하는 각 카테고리 메인화면에 선언 후, NavigationLink를 이용할떄 
`NavigationLink(destination: View().onAppear( isCustomTabBarHidden = true }` 처럼 해주면됩니다!

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #87 
