### PR TITLE
[Feature] 과목 페이지 내 과목명 수정화면 레이아웃 구현

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Application/BBANGZIPApp.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Application/BBANGZIPApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct BBANGZIPApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            CustomTabView()
         }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Card/StudyPieceCard/StudyPieceCard.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Card/StudyPieceCard/StudyPieceCard.swift
@@ -35,13 +35,10 @@ struct StudyPieceCard: View {
                 StudyCheckBox(state: state)
             }
             .padding(
-                .vertical,
-                10
-            )
-            .padding(
                 .horizontal,
                 16
             )
+            .frame(height: 86)
         }
     }
     
@@ -62,18 +59,6 @@ struct StudyPieceCard: View {
             alignment: .leading,
             spacing: 2
         ) {
-            
-//            CustomText(
-//                "\(StudyPieceCardData.subjectName) / \(StudyPieceCardData.examName)",
-//                fontType: .caption2Medium,
-//                color: Color(.labelAssistive)
-//            )
-//            .padding(
-//                .leading,
-//                4
-//            )
-            
-            
             CustomText(
                 StudyPieceCardData.studyContents,
                 fontType: .caption1Medium,

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
@@ -96,7 +96,7 @@ extension CustomNavigationBar {
             }
             .buttonStyle(PressedButtonStyle())
                                
-            NavigationLink(destination: Text("두 번째 화면")) {
+            NavigationLink(destination: ChangeSubjectNameView()) {
                 CustomText(
                     "과목명 수정하기",
                     fontType: .body1Bold,

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddStudyCard.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddStudyCard.swift
@@ -1,0 +1,49 @@
+//
+//  AddStudyCard.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/23/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct AddStudyCard: View {
+    
+    var body: some View {
+        ZStack {
+            backgroundView
+            
+            HStack(spacing: 8) {
+                CircleIcon(name: "Plus")
+                    .frame(
+                        width: 40,
+                        height: 40
+                    )
+                
+                CustomText(
+                    "공부 추가",
+                    fontType: .body1Bold,
+                    color: Color(.labelDisable)
+                )
+            }
+            .frame(height: 86)
+        }
+    }
+    
+    var backgroundView: some View {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(Color(.backgroundNormal))
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .stroke(
+                        Color(.lineAlternative),
+                        lineWidth: 2
+                    )
+            )
+    }
+}
+
+#Preview {
+    AddStudyCard()
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameView.swift
@@ -53,7 +53,7 @@ struct ChangeSubjectNameView: View {
 
                 Button("등록하기") {
                     print("click")
-                    viewModel.changeMotivationsubject()
+                    viewModel.changeSubjectName()
                     dismiss()
                 }
                 .buttonStyle(SolidButton(viewModel.isButtonEnabled))
@@ -83,14 +83,6 @@ struct ChangeSubjectNameView: View {
             TextField(
                 "기존 과목명",
                 text: $viewModel.subject
-            )
-            .textFieldStyle(
-                CustomTextFieldStyle(
-                    text: $viewModel.subject,
-                    style: .subject,
-                    state: viewModel.subjectState,
-                    alertText: viewModel.subjectAnnounceState
-                )
             )
             .focused($isSubjectFocused)
             .textFieldStyle(

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameView.swift
@@ -1,0 +1,122 @@
+//
+//  ChangeSubjectNameView.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/22/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+struct ChangeSubjectNameView: View {
+    @SwiftUI.Environment(\.dismiss) var dismiss
+    @StateObject private var viewModel: ChangeSubjectNameViewModel
+    @FocusState private var isSubjectFocused: Bool
+
+    init(
+        viewModel: ChangeSubjectNameViewModel = ChangeSubjectNameViewModel()
+    ) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        ZStack {
+            Color(.clear)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    hideKeyboard()
+                }
+
+            VStack {
+                CustomNavigationBar(
+                    showBackButton: true,
+                    showMenu: false,
+                    title: "과목명 수정하기",
+                    backgroundColor: Color(.backgroundNormal)
+                )
+
+                inputSection
+                    .padding(
+                        .top,
+                        48
+                    )
+                    .padding(
+                        .horizontal,
+                        20
+                    )
+
+                Spacer()
+            }
+
+            VStack {
+                Spacer()
+
+                Button("등록하기") {
+                    print("click")
+                    viewModel.changeMotivationsubject()
+                    dismiss()
+                }
+                .buttonStyle(SolidButton(viewModel.isButtonEnabled))
+                .disabled(!viewModel.isButtonEnabled)
+                .padding(
+                    .bottom,
+                    36
+                )
+            }
+            .padding(.horizontal, 20)
+            .ignoresSafeArea(edges: .bottom)
+        }
+        .navigationBarHidden(true)
+    }
+
+    var inputSection: some View {
+        VStack(spacing: 16){
+            HStack {
+                CustomText(
+                    "과목명",
+                    fontType: .body1Bold
+                )
+
+                Spacer()
+            }
+
+            TextField(
+                "기존 과목명",
+                text: $viewModel.subject
+            )
+            .textFieldStyle(
+                CustomTextFieldStyle(
+                    text: $viewModel.subject,
+                    style: .subject,
+                    state: viewModel.subjectState,
+                    alertText: viewModel.subjectAnnounceState
+                )
+            )
+            .focused($isSubjectFocused)
+            .textFieldStyle(
+                CustomTextFieldStyle(
+                    text: $viewModel.subject,
+                    style: .subject,
+                    state: viewModel.subjectState,
+                    alertText: viewModel.subjectAnnounceState
+                )
+            )
+            .onChange(of: viewModel.subject) { newSubject in
+                if newSubject.count > 10 {
+                    viewModel.subject = String(newSubject.prefix(10))
+                }
+                
+                viewModel.verifySubject(
+                    newText: newSubject,
+                    isSubjectFocused: isSubjectFocused
+                )
+            }
+            .onChange(of: isSubjectFocused) { isFocused in
+                viewModel.handleSubjectFocusChange(
+                    newText: viewModel.subject,
+                    isSubjectFocused: isSubjectFocused
+                )
+            }
+        }
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameViewModel.swift
@@ -1,0 +1,92 @@
+//
+//  ChangeSubjectNameViewModel.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/22/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+final class ChangeSubjectNameViewModel: ObservableObject {
+    @Published var subject: String
+    @Published var subjectAnnounceState: SubjectTextFieldAlertCase?
+    @Published var subjectState: TextFieldState
+    @Published var isSubjectFocused: Bool = false
+    @Published var isSubjectValid: Bool = false
+    @Published var isButtonEnabled: Bool = false
+    
+    init(
+        subject: String = "",
+        subjectAnnounceState: SubjectTextFieldAlertCase? = .alert,
+        subjectState: TextFieldState = .defaultState,
+        isSubjectFocused: Bool = false,
+        isSubjectValid: Bool = false,
+        isButtonEnabled: Bool = false
+    ) {
+        self.subject = subject
+        self.subjectAnnounceState = subjectAnnounceState
+        self.subjectState = subjectState
+        self.isSubjectFocused = isSubjectFocused
+        self.isSubjectValid = isSubjectValid
+        self.isButtonEnabled = isButtonEnabled
+    }
+    
+    func verifySubject(
+        newText: String,
+        isSubjectFocused: Bool
+    ) {
+        if isSubjectFocused {
+            subjectState = .typing
+            
+            if newText.isEmpty {
+                subjectState = .defaultState
+                subjectAnnounceState = .alert
+                isSubjectValid = false
+            } else {
+                if newText.isValidSubject {
+                    subjectState = .typing
+                    subjectAnnounceState = .enable
+                    isSubjectValid = true
+                } else {
+                    subjectState = .alert
+                    subjectAnnounceState = .alert
+                    isSubjectValid = false
+                }
+            }
+        } else if newText.isEmpty {
+            subjectState = .defaultState
+            subjectAnnounceState = .alert
+            isSubjectValid = false
+        }
+    }
+    
+    func handleSubjectFocusChange(
+        newText: String,
+        isSubjectFocused: Bool
+    ) {
+        if !isSubjectFocused {
+            if newText.isEmpty {
+                subjectState = .defaultState
+                isSubjectValid = false
+            } else if newText.isValidSubject {
+                subjectState = .field
+                subjectAnnounceState = .enable
+                isSubjectValid = true
+            } else {
+                subjectState = .alert
+                subjectAnnounceState = .alert
+                isSubjectValid = false
+            }
+        } else {
+            subjectState = .placeholder
+            isSubjectValid = false
+        }
+        
+        isButtonEnabled = subjectAnnounceState == .enable
+    }
+    
+    func changeMotivationsubject() {
+        // TODO: 과목명 변경 API 연동 필요
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameViewModel.swift
@@ -86,7 +86,7 @@ final class ChangeSubjectNameViewModel: ObservableObject {
         isButtonEnabled = subjectAnnounceState == .enable
     }
     
-    func changeMotivationsubject() {
+    func changeSubjectName() {
         // TODO: 과목명 변경 API 연동 필요
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailView.swift
@@ -115,6 +115,7 @@ struct SubjectDetailView: View {
                     }
                     .navigationBarHidden(true)
                 }
+                .scrollIndicators(.hidden)
                 .bottomSheet(
                     isShowing: $viewModel.isShowingBottomSheet,
                     height: 265

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailView.swift
@@ -102,6 +102,15 @@ struct SubjectDetailView: View {
                                     .horizontal,
                                     20
                                 )
+                                .padding(
+                                    .bottom,
+                                    16
+                                )
+                            
+                            if viewModel.isDeleteMode {
+                                Spacer()
+                                    .frame(height: 56)
+                            }
                         }
                     }
                     .navigationBarHidden(true)
@@ -115,31 +124,9 @@ struct SubjectDetailView: View {
                     }
                 }
                 
-                if viewModel.isDeleteMode {
-                    let title = viewModel.selectedItemCount == 0 ? "삭제하기" : "\(viewModel.selectedItemCount)개 삭제하기"
-                    
-                    VStack {
-                        Spacer()
-                        Button(title) {
-                            viewModel.deleteStudyPiece()
-                            viewModel.makeStudyPieceSelectable()
-                        }
-                        .buttonStyle(
-                            SolidIconButton(
-                                buttonImage: Image(.trash),
-                                viewModel.selectedItemCount > 0
-                            )
-                        )
-                        .padding(
-                            .horizontal,
-                            20
-                        )
-                        .padding(
-                            .bottom,
-                            8
-                        )
-                        .disabled(viewModel.selectedItemCount == 0)
-                    }
+                
+                if viewModel.isDeleteMode && viewModel.selectedItemCount > 0 {
+                    deleteButton
                 }
             }
         }
@@ -231,7 +218,6 @@ struct SubjectDetailView: View {
         }
     }
     
-    
     var studyPieceList: some View {
         VStack(spacing: 16) {
             ForEach(
@@ -264,6 +250,40 @@ struct SubjectDetailView: View {
                 .buttonStyle(PressedButtonStyle())
                 .customShadow(.normal)
             }
+            
+            // TODO: 공부 추가 화면으로 이동
+            if !viewModel.isDeleteMode {
+                NavigationLink(destination: Text("공부추가")){
+                    AddStudyCard()
+                }
+                .buttonStyle(PressedButtonStyle())
+            }
+        }
+    }
+    
+    var deleteButton: some View {
+        let title = "\(viewModel.selectedItemCount)개 삭제하기"
+        
+        return VStack {
+            Spacer()
+            
+            Button(title) {
+                viewModel.deleteStudyPiece()
+                viewModel.makeStudyPieceSelectable()
+            }
+            .buttonStyle(
+                SolidIconButton(
+                    buttonImage: Image(.trash)
+                )
+            )
+            .padding(
+                .horizontal,
+                20
+            )
+            .padding(
+                .bottom,
+                8
+            )
         }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageView.swift
@@ -71,6 +71,7 @@ struct SubjectManageView: View {
                         subjectSection
                         
                         subjectCardScrollSection
+                            .padding(.bottom, 16)
                     }
                     .padding(
                         .top,
@@ -81,7 +82,10 @@ struct SubjectManageView: View {
                         20
                     )
                     
-                    Spacer()
+                    if viewModel.isDeleteMode {
+                        Spacer()
+                            .frame(height: 56)
+                    }
                 }
                 .bottomSheet(
                     isShowing: $viewModel.isShowingBottomSheet,
@@ -106,7 +110,7 @@ struct SubjectManageView: View {
             VStack {
                 Spacer()
                 
-                if viewModel.isDeleteMode {
+                if viewModel.isDeleteMode && viewModel.selectedItemCount > 0 {
                     deleteButton
                         .padding(.bottom, 16)
                 }
@@ -200,12 +204,14 @@ struct SubjectManageView: View {
                 .customShadow(.normal)
             }
             
-            Button {
-                // TODO: 추가 페이지 이동
-            } label: {
-                SubjectAddCard()
+            if !viewModel.isDeleteMode {
+                Button {
+                    // TODO: 추가 페이지 이동
+                } label: {
+                    SubjectAddCard()
+                }
+                .buttonStyle(PressedButtonStyle())
             }
-            .buttonStyle(PressedButtonStyle())
         }
         .padding(
             .bottom,
@@ -214,7 +220,7 @@ struct SubjectManageView: View {
     }
     
     var deleteButton: some View {
-        let title = viewModel.selectedItemCount == 0 ? "삭제하기" : "\(viewModel.selectedItemCount)개 삭제하기"
+        let title = "\(viewModel.selectedItemCount)개 삭제하기"
         
         return VStack {
             Spacer()
@@ -225,8 +231,7 @@ struct SubjectManageView: View {
             }
             .buttonStyle(
                 SolidIconButton(
-                    buttonImage: Image(.trash),
-                    viewModel.selectedItemCount > 0
+                    buttonImage: Image(.trash)
                 )
             )
             .padding(
@@ -237,7 +242,6 @@ struct SubjectManageView: View {
                 .bottom,
                 8
             )
-            .disabled(viewModel.selectedItemCount == 0)
         }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageView.swift
@@ -36,98 +36,134 @@ struct SubjectManageView: View {
     ]
     
     var body: some View {
-        ScrollView {
-            VStack {
-                HStack {
-                    ChangeSemesterButton(viewModel: viewModel)
-                        .padding(
-                            .leading,
-                            24
-                        )
+        ZStack {
+            ScrollView {
+                VStack {
+                    HStack {
+                        ChangeSemesterButton(viewModel: viewModel)
+                            .padding(
+                                .leading,
+                                24
+                            )
+                        
+                        Spacer()
+                    }
+                    .padding(
+                        .top,
+                        55
+                    )
+                    .padding(
+                        .bottom,
+                        169
+                    )
+                    .background(
+                        Color(.backgroundAccent)
+                            .cornerRadius(
+                                32,
+                                corners: [
+                                    .bottomLeft,
+                                    .bottomRight
+                                ]
+                            )
+                    )
+                    
+                    VStack(spacing: 32) {
+                        subjectSection
+                        
+                        subjectCardScrollSection
+                    }
+                    .padding(
+                        .top,
+                        48
+                    )
+                    .padding(
+                        .horizontal,
+                        20
+                    )
                     
                     Spacer()
                 }
-                .padding(
-                    .top,
-                    55
-                )
-                .padding(
-                    .bottom,
-                    169
-                )
-                .background(
-                    Color(.backgroundAccent)
-                        .cornerRadius(
-                            32,
-                            corners: [
-                                .bottomLeft,
-                                .bottomRight
-                            ]
-                        )
-                )
-                
-                VStack(spacing: 32) {
-                    subjectSection
-                    
-                    subjectCardScrollSection
+                .bottomSheet(
+                    isShowing: $viewModel.isShowingBottomSheet,
+                    height: 453
+                ) {
+                    if let type = selectedBottomSheetType {
+                        type.contentView(isPresented: $viewModel.isShowingBottomSheet)
+                    }
                 }
-                .padding(
-                    .top,
-                    48
-                )
-                .padding(
-                    .horizontal,
-                    20
-                )
-                
+                .onChange(of: viewModel.isShowingBottomSheet) { newValue in
+                    isBottomSheetShowing = newValue
+                }
+                .onAppear {
+                    viewModel.fetchSubjectData()
+                    viewModel.isDeleteMode = false
+                    isCustomTabBarHidden = false
+                }
+            }
+            .edgesIgnoringSafeArea(.top)
+            .scrollIndicators(.hidden)
+            
+            VStack {
                 Spacer()
-            }
-            .bottomSheet(
-                isShowing: $viewModel.isShowingBottomSheet,
-                height: 453
-            ) {
-                if let type = selectedBottomSheetType {
-                    type.contentView(isPresented: $viewModel.isShowingBottomSheet)
+                
+                if viewModel.isDeleteMode {
+                    deleteButton
+                        .padding(.bottom, 16)
                 }
-            }
-            .onChange(of: viewModel.isShowingBottomSheet) { newValue in
-                isBottomSheetShowing = newValue
-            }
-            .onAppear {
-                viewModel.fetchSubjectData()
-                isCustomTabBarHidden = false
             }
         }
-        .edgesIgnoringSafeArea(.top)
-        .scrollIndicators(.hidden)
-        
     }
     
     var subjectSection: some View {
-        HStack {
-            CustomText(
-                "어떤 과목을 공부해 볼까요?",
-                fontType: .headline2Bold,
-                color: Color(.labelAlternative)
-            )
-            
-            Spacer()
-            
-            Button {
-                viewModel.deleteSubject()
-            } label: {
-                Image(.trash)
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(
-                        width: 24,
-                        height: 24
-                    )
-                    .foregroundStyle(Color(.labelAssistive))
+        if viewModel.isDeleteMode {
+            HStack {
+                CustomText(
+                    "삭제할 과목을 선택해 주세요",
+                    fontType: .headline2Bold,
+                    color: Color(.labelAlternative)
+                )
+                
+                Spacer()
+                
+                Button {
+                    viewModel.makeSelectableSubject()
+                } label: {
+                    Image(.xSmall)
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(
+                            width: 24,
+                            height: 24
+                        )
+                        .foregroundStyle(Color(.labelAssistive))
+                }
+            }
+        } else {
+            HStack(spacing: 16) {
+                CustomText(
+                    "어떤 과목을 공부해 볼까요?",
+                    fontType: .headline2Bold,
+                    color: Color(.labelAlternative)
+                )
+                
+                Spacer()
+                
+                Button {
+                    viewModel.makeSelectableSubject()
+                } label: {
+                    Image(.trash)
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(
+                            width: 24,
+                            height: 24
+                        )
+                        .foregroundStyle(Color(.labelAlternative))
+                }
             }
         }
     }
+    
     
     var subjectCardScrollSection: some View {
         LazyVGrid(
@@ -139,25 +175,29 @@ struct SubjectManageView: View {
                 id: \.self
             ) {
                 $model in
-//                Button {
-//                    model.state = model.state == .cardDefault ? .cardDefault : model.state == .selectable ? .selected : .selectable
-//                } label: {
-//                    SubjectCard(
-//                        state: model.state,
-//                        subjectCardData: model
-//                    )
-//                }
-//                .buttonStyle(PressedButtonStyle())
-                
-                NavigationLink(destination: SubjectDetailView(viewModel: SubjectDetailViewModel(modelList: StudyPieceModel.mockList), isBottomSheetShowing: $isBottomSheetShowing)
-                    .onAppear { isCustomTabBarHidden = true }
-                ) {
-                    SubjectCard(
-                        state: model.state,
-                        subjectCardData: model
-                    )
+                Button {
+                    model.state = model.state == .cardDefault ? .cardDefault : model.state == .selectable ? .selected : .selectable
+                    viewModel.validateDeleteButton()
+                } label: {
+                    if model.state == .cardDefault {
+                        NavigationLink(destination: SubjectDetailView(viewModel: SubjectDetailViewModel(modelList: StudyPieceModel.mockList), isBottomSheetShowing: $isBottomSheetShowing)
+                        .onAppear { isCustomTabBarHidden = true }
+                        ) {
+                            SubjectCard(
+                                state: model.state,
+                                subjectCardData: model
+                            )
+                        }
+                        .buttonStyle(PressedButtonStyle())
+                    } else {
+                        SubjectCard(
+                            state: model.state,
+                            subjectCardData: model
+                        )
+                    }
                 }
                 .buttonStyle(PressedButtonStyle())
+                .customShadow(.normal)
             }
             
             Button {
@@ -169,7 +209,35 @@ struct SubjectManageView: View {
         }
         .padding(
             .bottom,
-            76
+            20
         )
+    }
+    
+    var deleteButton: some View {
+        let title = viewModel.selectedItemCount == 0 ? "삭제하기" : "\(viewModel.selectedItemCount)개 삭제하기"
+        
+        return VStack {
+            Spacer()
+            
+            Button(title) {
+                viewModel.deleteStudy()
+                viewModel.makeSelectableSubject()
+            }
+            .buttonStyle(
+                SolidIconButton(
+                    buttonImage: Image(.trash),
+                    viewModel.selectedItemCount > 0
+                )
+            )
+            .padding(
+                .horizontal,
+                20
+            )
+            .padding(
+                .bottom,
+                8
+            )
+            .disabled(viewModel.selectedItemCount == 0)
+        }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectManage/SubjectManageViewModel.swift
@@ -10,7 +10,13 @@ import SwiftUI
 
 final class SubjectManageViewModel: ObservableObject {
     @Published var isShowingBottomSheet: Bool
+    @Published var isDeleteMode: Bool = false
+    @Published var isDeleteButtonEnable: Bool = false
     @Published var modelList: [SubjectCardModel]
+    
+    var selectedItemCount: Int {
+        modelList.filter { $0.state == .selected }.count
+    }
     
     init(
         isShowingBottomSheet: Bool = false,
@@ -24,21 +30,25 @@ final class SubjectManageViewModel: ObservableObject {
         isShowingBottomSheet = true
     }
     
-    func deleteSubject() {
-        let currentState: SubjectCardState = modelList.first?.state ?? SubjectCardState.cardDefault
-        
-        let newState: SubjectCardState = switch currentState {
-        case SubjectCardState.cardDefault:
-            SubjectCardState.selectable
-        case SubjectCardState.selectable:
-            SubjectCardState.cardDefault
-        default:
-            currentState
+    func makeDeleteMode() {
+        isDeleteMode.toggle()
+    }
+    
+    func makeSelectableSubject() {
+        isDeleteMode.toggle()
+        modelList = modelList.map {
+            var updatedModel = $0
+            updatedModel.state = $0.state == .cardDefault ? .selectable : .cardDefault
+            return updatedModel
         }
+    }
+    
+    func validateDeleteButton() {
+        isDeleteButtonEnable = modelList.count(where: { $0.state == .selected }) > 0
+    }
+    
+    func deleteStudy() {
         
-        for i in modelList.indices {
-            modelList[i].state = newState
-        }
     }
     
     func fetchSubjectData() {


### PR DESCRIPTION
## 🥖 What is the PR?

과목 페이지 내 과목명 수정화면 레이아웃 구현

## 🥐 Changes

- ChangeSubjectNameView 구현
- AddStudyCard 구현
- 상세 레이아웃 수정

## 🥯 Thoughts

- TextField를 적용하였습니다. 
- 이동하는 버튼이지만, 다른 액션을 줘야할때 NavigationLink와 Button을 함께 사용하여 구현하였습니다.
```
Button {
                    model.state = model.state == .cardDefault ? .cardDefault : model.state == .selectable ? .selected : .selectable
                    viewModel.validateDeleteButton()
                } label: {
                    if model.state == .cardDefault {
                        NavigationLink(destination: SubjectDetailView(viewModel: SubjectDetailViewModel(modelList: StudyPieceModel.mockList), isBottomSheetShowing: $isBottomSheetShowing)
                        .onAppear { isCustomTabBarHidden = true }
                        ) {
                            SubjectCard(
                                state: model.state,
                                subjectCardData: model
                            )
                        }
                        .buttonStyle(PressedButtonStyle())
                    } else {
                        SubjectCard(
                            state: model.state,
                            subjectCardData: model
                        )
                    }
                }
                .buttonStyle(PressedButtonStyle())
                .customShadow(.normal)
```

## 🥪 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 올바르지 않은 과목명 | 올바른 과목명 |
| --- | --- |
|<img width="339" alt="image" src="https://github.com/user-attachments/assets/e692e691-4431-4803-a770-a87aaee40409" />|
<img width="369" alt="image" src="https://github.com/user-attachments/assets/f20bea34-6518-4a4f-bc90-916544938fa6" />
|

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #91
