### PR TITLE
[Feature] 과목명/과목 별 동기부여 메세지 작성 및 수정 API 연동

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/BbangDefaultRouter.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/BbangDefaultRouter.swift
@@ -17,7 +17,6 @@ enum BbangDefaultRouter {
     case withDraw
     case onBoarding
     case testSelect(subjectID: Int)
-    case motivationMessage(subjectID: Int, options: String)
     case addStudyScope
     case deleteStudyScope
     case studyCompleteCheck(pieceID: Float)
@@ -45,6 +44,7 @@ enum BbangDefaultRouter {
     case fetchSubject(dto: FetchSubjectRequestDTO)
     case addSubject(dto: AddSubjectRequestDTO)
     case deleteSubject(dto: DeleteSubjectRequestDTO)
+    case changeName(subjectID: Int, options: String, dto: ChangeNameRequestDTO)
     
 }
 
@@ -71,8 +71,8 @@ extension BbangDefaultRouter: Router {
             return "/api/v1/exam/\(subjectID)"
         case .addSubject:
             return "/api/v1/subjects"
-        case .motivationMessage(let subjectID, let options):
-            return "/api/v1/subjects/\(subjectID)/\(options)"
+        case .changeName(let subjectId, let options, _):
+            return "/api/v1/subjects/\(subjectId)/\(options)"
         case .addStudyScope:
             return "/api/v1/studies"
         case .deleteStudyScope:
@@ -133,7 +133,6 @@ extension BbangDefaultRouter: Router {
         case
                 .examFiltering,
                 .testSelect,
-                .motivationMessage,
                 .fetchSortedTodoList,
                 .sortedDelayedTodoList,
                 .myPageStatus,
@@ -154,6 +153,9 @@ extension BbangDefaultRouter: Router {
         case .studyCompleteCheck,
                 .notCompletedCheck:
             return .patch
+            
+        case .changeName:
+            return .put
         }
     }
     
@@ -177,14 +179,8 @@ extension BbangDefaultRouter: Router {
             return dto.asDictionary()
         case .testSelect(let subjectID):
             return ["subjectID": subjectID]
-        case .motivationMessage(
-            let subjectID,
-            let options
-        ):
-            return [
-                "subjectID": subjectID,
-                "options": options
-            ]
+        case .changeName(_, _, let dto):
+            return dto.asDictionary()
         case .studyCompleteCheck(let pieceID), .notCompletedCheck(let pieceID):
             return ["pieceID": pieceID]
         case .badgeDetail(let badgeID):

--- a/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/DataMapping/Request/ChangeNameRequestDTO.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/DataMapping/Request/ChangeNameRequestDTO.swift
@@ -1,0 +1,11 @@
+//
+//  MotivationMessageRequestDTO.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/24/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+struct ChangeNameRequestDTO: Encodable {
+    let value: String
+}

--- a/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/DataMapping/Response/ChangeNameResponseDTO.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/DataMapping/Response/ChangeNameResponseDTO.swift
@@ -1,0 +1,11 @@
+//
+//  MotivationMessageResponseDTO.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/24/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+struct ChangeNameResponseDTO: Decodable {
+    let code: ResponseCodeDTO
+}

--- a/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/DataMapping/Response/FilterExamResponseDTO.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Data/Network/Router/DataMapping/Response/FilterExamResponseDTO.swift
@@ -12,14 +12,14 @@ struct FilterExamResponseDTO: Decodable {
 }
 
 struct FilterExamDTO: Decodable {
-    let motivationMessage: String
+    let motivationMessage: String?
     let examDday: Int
     let examDate: String
     let studyList: [ExamListDTO]
     
     func toDomain() -> FilterExamContent {
         FilterExamContent(
-            motivationMessage: motivationMessage,
+            motivationMessage: motivationMessage ?? "",
             examDday: examDday,
             examDate: examDate,
             studyList: studyList.map { $0.toDomain() }

--- a/BBANGZIP/BBANGZIP/Sources/Data/Repositories/DefaultMessageRepository.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Data/Repositories/DefaultMessageRepository.swift
@@ -1,0 +1,36 @@
+//
+//  DefaultMessageRepository.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/24/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+import Alamofire
+
+final class DefaultMessageRepository: MessageRepository {
+    
+    func motivationMessage(
+        subjectId: Int,
+        options: String,
+        value: String
+    ) async throws {
+        let response = await API.session.request(
+            BbangDefaultRouter.changeName(
+                subjectID: subjectId,
+                options: options,
+                dto: ChangeNameRequestDTO(value: value)
+            )
+        )
+            .serializingDecodable(ChangeNameResponseDTO.self)
+            .response
+        
+        switch response.result {
+        case .success(let resultDTO):
+            dump(resultDTO)
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Domain/Interfaces/Repositories/MessageRepository.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Domain/Interfaces/Repositories/MessageRepository.swift
@@ -1,0 +1,11 @@
+//
+//  MessageRepository.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/24/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+protocol MessageRepository: Sendable {
+    func motivationMessage(subjectId: Int, options: String, value: String) async throws
+}

--- a/BBANGZIP/BBANGZIP/Sources/Domain/UseCases/ChangeNameUseCase.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Domain/UseCases/ChangeNameUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  ChangeNameUseCase.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 1/24/25.
+//  Copyright © 2025 com.bbangzip. All rights reserved.
+//
+
+protocol ChangeNameUseCase: Sendable {
+    func execute(
+        subjectId: Int,
+        options: String,
+        value: String
+    ) async throws
+}
+
+final class DefaultChangeNameUseCase {
+    private let repository: MessageRepository
+    
+    init(repository: MessageRepository) {
+        self.repository = repository
+    }
+}
+
+extension DefaultChangeNameUseCase: ChangeNameUseCase {
+    func execute(
+        subjectId: Int,
+        options: String,
+        value: String
+    ) async throws  {
+        return try await repository.motivationMessage(
+            subjectId: subjectId,
+            options: options,
+            value: value
+        )
+    }
+}

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/AddSubject/View/AddSubjectView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/AddSubject/View/AddSubjectView.swift
@@ -80,13 +80,11 @@ struct AddSubjectView: View {
             }
         }
         .navigationBarHidden(true)
-        .onChange(of: viewModel.shouldDismiss) {
-            shouldDismiss in
-            if shouldDismiss {
+        .onAppear {
+            if viewModel.shouldDismiss {
                 dismiss()
             }
         }
-        .toastView(toast: $viewModel.toast)
     }
     
     private var subjectTextField: some View {

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/AddSubject/ViewModel/AddSubjectViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/AddSubject/ViewModel/AddSubjectViewModel.swift
@@ -114,7 +114,6 @@ class AddSubjectViewModel: ObservableObject {
                 "이미 등록된 과목이에요",
                 startFrom: 76
             )
-            
             dump(error)
             print(error)
         }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
@@ -96,7 +96,9 @@ extension CustomNavigationBar {
             NavigationLink(
                 destination: AddMotivationMessageView(
                     viewModel: AddMotivationMessageViewModel(
-                        changeNameUseCase: DefaultChangeNameUseCase(repository: DefaultMessageRepository()),
+                        changeNameUseCase: DefaultChangeNameUseCase(
+                            repository: DefaultMessageRepository()
+                        ),
                         parentViewModel: SubjectDetailViewModel(
                             filterExamUseCase: DefaultFilterExamUseCase(
                                 examRepository: DefaultExamRepository()
@@ -114,7 +116,20 @@ extension CustomNavigationBar {
             }
             .buttonStyle(PressedButtonStyle())
                                
-            NavigationLink(destination: ChangeSubjectNameView()) {
+            NavigationLink(
+                destination: ChangeSubjectNameView(
+                    viewModel: ChangeSubjectNameViewModel(
+                        changeNameUseCase: DefaultChangeNameUseCase(
+                            repository: DefaultMessageRepository()),
+                        parentViewModel: SubjectDetailViewModel(
+                                filterExamUseCase: DefaultFilterExamUseCase(
+                                    examRepository: DefaultExamRepository()
+                                ),
+                                subjectId: viewModel.subjectId
+                        )
+                    ), subjectName: viewModel.subjectName
+                )
+            ) {
                 CustomText(
                     "과목명 수정하기",
                     fontType: .body1Bold,

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/CustomNavigationBar.swift
@@ -14,6 +14,7 @@ struct CustomNavigationBar: View {
     private let showMenu: Bool
     private let title: String
     private let backgroundColor: Color?
+    @EnvironmentObject private var viewModel: SubjectDetailViewModel
     
     init(
         showBackButton: Bool,
@@ -92,7 +93,19 @@ extension CustomNavigationBar {
     private var kebabButton: some View {
         // TODO: custom으로 수정 필요
         Menu {
-            NavigationLink(destination: AddMotivationMessageView()) {
+            NavigationLink(
+                destination: AddMotivationMessageView(
+                    viewModel: AddMotivationMessageViewModel(
+                        changeNameUseCase: DefaultChangeNameUseCase(repository: DefaultMessageRepository()),
+                        parentViewModel: SubjectDetailViewModel(
+                            filterExamUseCase: DefaultFilterExamUseCase(
+                                examRepository: DefaultExamRepository()
+                            ),
+                            subjectId: viewModel.subjectId
+                        )
+                    )
+                )
+            ) {
                 CustomText(
                     "각오 한 마디 작성하기",
                     fontType: .body1Bold,

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageView.swift
@@ -14,7 +14,7 @@ struct AddMotivationMessageView: View {
     @FocusState private var isMessageFocused: Bool
     
     init(
-        viewModel: AddMotivationMessageViewModel = AddMotivationMessageViewModel()
+        viewModel: AddMotivationMessageViewModel
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -52,9 +52,9 @@ struct AddMotivationMessageView: View {
                 Spacer()
                 
                 Button("등록하기") {
-                    print("click")
-                    viewModel.changeMotivationMessage()
-                    dismiss()
+                    Task {
+                        await viewModel.changeMotivationMessage()
+                    }
                 }
                 .buttonStyle(SolidButton(viewModel.isButtonEnabled))
                 .disabled(!viewModel.isButtonEnabled)
@@ -67,6 +67,12 @@ struct AddMotivationMessageView: View {
             .ignoresSafeArea(edges: .bottom)
         }
         .navigationBarHidden(true)
+        .onChange(of: viewModel.shouldDismiss) {
+            shouldDismiss in
+            if shouldDismiss {
+                dismiss()
+            }
+        }
     }
     
     var inputSection: some View {

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/AddMotivationMessageViewModel.swift
@@ -9,20 +9,29 @@
 import SwiftUI
 
 final class AddMotivationMessageViewModel: ObservableObject {
+    private let changeNameUseCase: ChangeNameUseCase
+    private let parentViewModel: SubjectDetailViewModel
+    
     @Published var message: String
     @Published var messageAnnounceState: MessageTextFieldAlertCase?
     @Published var messageState: TextFieldState
     @Published var isMessageFocused: Bool = false
     @Published var isMessageValid: Bool = false
     @Published var isButtonEnabled: Bool = false
+    @Published var shouldDismiss: Bool = false
+    @Published var toast: Toast?
     
     init(
+        changeNameUseCase: ChangeNameUseCase,
+        parentViewModel: SubjectDetailViewModel,
         message: String = "",
         messageAnnounceState: MessageTextFieldAlertCase? = .alert,
         messageState: TextFieldState = .defaultState,
         isMessageFocused: Bool = false,
         isMessageValid: Bool = false
     ) {
+        self.changeNameUseCase = changeNameUseCase
+        self.parentViewModel = parentViewModel
         self.message = message
         self.messageAnnounceState = messageAnnounceState
         self.messageState = messageState
@@ -75,7 +84,27 @@ final class AddMotivationMessageViewModel: ObservableObject {
         isButtonEnabled = messageAnnounceState == .enable
     }
     
-    func changeMotivationMessage() {
-        // TODO: 동기부여 메시지 작성 및 수정 API 연동 필요
+    @MainActor
+    func changeMotivationMessage() async {
+        do {
+            let _: () = try await changeNameUseCase.execute(
+                subjectId: parentViewModel.subjectId,
+                options: "motivationMessage",
+                value: message
+            )
+            
+            await parentViewModel.fetchData()
+                    
+            parentViewModel.toast = Toast(
+                "각오 한 마디 작성 완료!",
+                startFrom: 20
+            )
+                    
+            self.shouldDismiss = true
+            
+        } catch {
+            dump(error)
+            print(error)
+        }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameView.swift
@@ -12,11 +12,14 @@ struct ChangeSubjectNameView: View {
     @SwiftUI.Environment(\.dismiss) var dismiss
     @StateObject private var viewModel: ChangeSubjectNameViewModel
     @FocusState private var isSubjectFocused: Bool
+    private let subjectName: String
 
     init(
-        viewModel: ChangeSubjectNameViewModel = ChangeSubjectNameViewModel()
+        viewModel: ChangeSubjectNameViewModel,
+        subjectName: String
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        self.subjectName = subjectName
     }
 
     var body: some View {
@@ -52,9 +55,9 @@ struct ChangeSubjectNameView: View {
                 Spacer()
 
                 Button("등록하기") {
-                    print("click")
-                    viewModel.changeSubjectName()
-                    dismiss()
+                    Task {
+                        await viewModel.changeSubjectName()
+                    }
                 }
                 .buttonStyle(SolidButton(viewModel.isButtonEnabled))
                 .disabled(!viewModel.isButtonEnabled)
@@ -67,6 +70,12 @@ struct ChangeSubjectNameView: View {
             .ignoresSafeArea(edges: .bottom)
         }
         .navigationBarHidden(true)
+        .onChange(of: viewModel.shouldDismiss) {
+            shouldDismiss in
+            if shouldDismiss {
+                dismiss()
+            }
+        }
     }
 
     var inputSection: some View {
@@ -81,7 +90,7 @@ struct ChangeSubjectNameView: View {
             }
 
             TextField(
-                "기존 과목명",
+                subjectName,
                 text: $viewModel.subject
             )
             .focused($isSubjectFocused)

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/ChangeSubjectNameViewModel.swift
@@ -9,14 +9,21 @@
 import SwiftUI
 
 final class ChangeSubjectNameViewModel: ObservableObject {
+    private let changeNameUseCase: ChangeNameUseCase
+    private let parentViewModel: SubjectDetailViewModel
+    
     @Published var subject: String
     @Published var subjectAnnounceState: SubjectTextFieldAlertCase?
     @Published var subjectState: TextFieldState
     @Published var isSubjectFocused: Bool = false
     @Published var isSubjectValid: Bool = false
     @Published var isButtonEnabled: Bool = false
+    @Published var shouldDismiss: Bool = false
+    @Published var toast: Toast?
     
     init(
+        changeNameUseCase: ChangeNameUseCase,
+        parentViewModel: SubjectDetailViewModel,
         subject: String = "",
         subjectAnnounceState: SubjectTextFieldAlertCase? = .alert,
         subjectState: TextFieldState = .defaultState,
@@ -24,6 +31,8 @@ final class ChangeSubjectNameViewModel: ObservableObject {
         isSubjectValid: Bool = false,
         isButtonEnabled: Bool = false
     ) {
+        self.changeNameUseCase = changeNameUseCase
+        self.parentViewModel = parentViewModel
         self.subject = subject
         self.subjectAnnounceState = subjectAnnounceState
         self.subjectState = subjectState
@@ -86,7 +95,27 @@ final class ChangeSubjectNameViewModel: ObservableObject {
         isButtonEnabled = subjectAnnounceState == .enable
     }
     
-    func changeSubjectName() {
-        // TODO: 과목명 변경 API 연동 필요
+    @MainActor
+    func changeSubjectName() async {
+        do {
+            let _: () = try await changeNameUseCase.execute(
+                subjectId: parentViewModel.subjectId,
+                options: "subjectName",
+                value: subject
+            )
+            
+            await parentViewModel.fetchData()
+                    
+            parentViewModel.toast = Toast(
+                "과목명 수정 완료!",
+                startFrom: 20
+            )
+                    
+            self.shouldDismiss = true
+            
+        } catch {
+            dump(error)
+            print(error)
+        }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailView.swift
@@ -23,133 +23,136 @@ struct SubjectDetailView: View {
     }
     
     var body: some View {
-        if viewModel.isLoading {
-            ProgressView()
-                .navigationBarHidden(true)
-                .onAppear {
-                    Task { @MainActor in
-                        await viewModel.fetchData()
-                    }
-                }
-        } else {
-            VStack(spacing: 0) {
-                CustomNavigationBar(
-                    showBackButton: true,
-                    showMenu: true,
-                    title: viewModel.subjectName,
-                    backgroundColor: Color(.backgroundAccent)
-                )
-                
-                ZStack {
-                    ScrollView {
-                        ZStack {
-                            VStack {
-                                Color(.backgroundAccent)
-                                    .frame(
-                                        height: 153
-                                    )
-                                    .cornerRadius(
-                                        32,
-                                        corners: [
-                                            .bottomLeft,
-                                            .bottomRight
-                                        ]
-                                    )
-                                    .ignoresSafeArea(
-                                        .all,
-                                        edges: .top
-                                    )
-                                
-                                Spacer()
-                            }
-                            
-                            
-                            VStack(spacing: 16) {
-                                backgroundView
-                                    .padding(
-                                        .top,
-                                        25
-                                    )
-                                
-                                MenuTab(
-                                    tabNames: [
-                                        "중간고사",
-                                        "기말고사"
-                                    ]
-                                ) { selectedTab in
-                                    Task {
-                                        await viewModel.updateExam(selectedTab)
-                                    }
-                                }
-                                .padding(
-                                    .top,
-                                    28
-                                )
-                                .padding(
-                                    .horizontal,
-                                    20
-                                )
-                                
-                                // 시작점
-                                if viewModel.modelList.isEmpty {
-                                    emptyView
-                                } else {
-                                    HStack(spacing: 8) {
-                                        Chip(type: .daysLeftWithText(-24))
-                                        
-                                        CustomText(
-                                            "2025년 5월 13일",
-                                            fontType: .label1Bold,
-                                            color: Color(.labelAlternative)
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .navigationBarHidden(true)
+            } else {
+                VStack(spacing: 0) {
+                    CustomNavigationBar(
+                        showBackButton: true,
+                        showMenu: true,
+                        title: viewModel.subjectName,
+                        backgroundColor: Color(.backgroundAccent)
+                    )
+                    .environmentObject(viewModel)
+                    
+                    ZStack {
+                        ScrollView {
+                            ZStack {
+                                VStack {
+                                    Color(.backgroundAccent)
+                                        .frame(
+                                            height: 153
                                         )
-                                    }
+                                        .cornerRadius(
+                                            32,
+                                            corners: [
+                                                .bottomLeft,
+                                                .bottomRight
+                                            ]
+                                        )
+                                        .ignoresSafeArea(
+                                            .all,
+                                            edges: .top
+                                        )
                                     
-                                    studyListHeaderView
+                                    Spacer()
+                                }
+                                
+                                
+                                VStack(spacing: 16) {
+                                    backgroundView
                                         .padding(
                                             .top,
-                                            32
-                                        )
-                                        .padding(
-                                            .horizontal,
-                                            20
+                                            25
                                         )
                                     
-                                    studyPieceList
-                                        .padding(
-                                            .horizontal,
-                                            20
-                                        )
-                                        .padding(
-                                            .bottom,
-                                            16
-                                        )
-                                }
-                                
-                                if viewModel.isDeleteMode {
-                                    Spacer()
-                                        .frame(height: 56)
+                                    MenuTab(
+                                        tabNames: [
+                                            "중간고사",
+                                            "기말고사"
+                                        ]
+                                    ) { selectedTab in
+                                        Task {
+                                            await viewModel.updateExam(selectedTab)
+                                        }
+                                    }
+                                    .padding(
+                                        .top,
+                                        28
+                                    )
+                                    .padding(
+                                        .horizontal,
+                                        20
+                                    )
+                                    
+                                    // 시작점
+                                    if viewModel.modelList.isEmpty {
+                                        emptyView
+                                    } else {
+                                        HStack(spacing: 8) {
+                                            Chip(type: .daysLeftWithText(-24))
+                                            
+                                            CustomText(
+                                                "2025년 5월 13일",
+                                                fontType: .label1Bold,
+                                                color: Color(.labelAlternative)
+                                            )
+                                        }
+                                        
+                                        studyListHeaderView
+                                            .padding(
+                                                .top,
+                                                32
+                                            )
+                                            .padding(
+                                                .horizontal,
+                                                20
+                                            )
+                                        
+                                        studyPieceList
+                                            .padding(
+                                                .horizontal,
+                                                20
+                                            )
+                                            .padding(
+                                                .bottom,
+                                                16
+                                            )
+                                    }
+                                    
+                                    if viewModel.isDeleteMode {
+                                        Spacer()
+                                            .frame(height: 56)
+                                    }
                                 }
                             }
+                            .navigationBarHidden(true)
                         }
-                        .navigationBarHidden(true)
-                    }
-                    .scrollIndicators(.hidden)
-                    .bottomSheet(
-                        isShowing: $viewModel.isShowingBottomSheet,
-                        height: 265
-                    ) {
-                        if let type = selectedBottomSheetType {
-                            type.contentView(
-                                isPresented: $viewModel.isShowingBottomSheet
-                            )
+                        .scrollIndicators(.hidden)
+                        .bottomSheet(
+                            isShowing: $viewModel.isShowingBottomSheet,
+                            height: 265
+                        ) {
+                            if let type = selectedBottomSheetType {
+                                type.contentView(
+                                    isPresented: $viewModel.isShowingBottomSheet
+                                )
+                            }
+                        }
+                        
+                        if viewModel.isDeleteMode && viewModel.selectedItemCount > 0 {
+                            deleteButton
                         }
                     }
-                    
-                    
-                    if viewModel.isDeleteMode && viewModel.selectedItemCount > 0 {
-                        deleteButton
-                    }
+                    .toastView(toast: $viewModel.toast)
                 }
+            }
+        }
+        .onAppear {
+            Task {
+                await viewModel.fetchData()
             }
         }
     }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailViewModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/SubjectDetail/SubjectDetailViewModel.swift
@@ -12,7 +12,7 @@ final class SubjectDetailViewModel: ObservableObject {
     private let filterExamUseCase: FilterExamUseCase
     
     let subjectName: String
-    private let subjectId: Int
+    let subjectId: Int
     @Published var currentExam: String = "중간고사"
     @Published var motivationMessage: String = ""
     @Published var modelList: [FilterExamList] = []
@@ -20,6 +20,7 @@ final class SubjectDetailViewModel: ObservableObject {
     @Published var isLoading: Bool = true
     @Published var isDeleteButtonEnable: Bool = false
     @Published var isShowingBottomSheet: Bool = false
+    @Published var toast: Toast?
     
     var selectedItemCount: Int {
         modelList.filter { $0.state == .selected }.count


### PR DESCRIPTION
## 🥖 What is the PR?

과목명/과목 별 동기부여 메세지 작성 및 수정 API 연동하였습니다.

## 🥐 Changes

- 과목명 수정 API를 연동하였습니다.
- 동기부여 메세지 작성 및 수정 API를 연동하였습니다.

## 🥯 Thoughts

- 무거워지는 뷰모델 주입을 신경쓸 필요가 있다고 생각합니다.

## 🥪 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 화면 |
| --- |
| <img width="369" alt="image" src="https://github.com/user-attachments/assets/97da05c3-54be-4537-9f03-f6b8900190e8" /> |

## 🥨 To Reviewers

- 토스트 메시지 노출 로직 개선이 필요합니다
- CustomNavigationBar 내 과목명도 동기화 될 수 있도록 개선이 필요합니다

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #100 
