### PR TITLE
[Feature] Subject examName 필터링 내부 로직 구현 

### DIFF
--- a/BBANGZIP/BBANGZIP/Sources/Domain/Entities/SubjectCardModel.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Domain/Entities/SubjectCardModel.swift
@@ -28,7 +28,9 @@ extension SubjectStudyModel {
 
 extension SubjectCardModel {
     var hasValidStudy: Bool {
-        guard let firstStudy = studyList.first else { return false }
-        return firstStudy.isValidExam
+        
+        return studyList.contains { study in
+            (study.examName == "중간고사" || study.examName == "기말고사") && study.isValidExam
+        }
     }
 }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Card/SubjectCard/SubjectCard.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Component/Card/SubjectCard/SubjectCard.swift
@@ -4,9 +4,6 @@ struct SubjectCard: View {
     private var state: CardState
     private let subjectCardData: SubjectCardModel
     private let borderPadding: CGFloat = 2
-    private var shouldShowEmptyState: Bool {
-        return !subjectCardData.hasValidStudy
-    }
     
     init(
         state: CardState,
@@ -16,9 +13,23 @@ struct SubjectCard: View {
         self.subjectCardData = subjectCardData
     }
     
-    private var firstStudy: SubjectStudyModel? {
+    private var shouldShowEmptyState: Bool {
         
-        return subjectCardData.studyList.first
+        return priorityStudy == nil
+    }
+
+    private var priorityStudy: SubjectStudyModel? {
+        let midtermStudy = subjectCardData.studyList.filter { $0.examName == "중간고사" && $0.isValidExam }
+        let finalStudy = subjectCardData.studyList.filter { $0.examName == "기말고사" && $0.isValidExam }
+        
+        if !midtermStudy.isEmpty {
+            return midtermStudy.first
+        }
+        if !finalStudy.isEmpty {
+            return finalStudy.first
+        }
+        
+        return nil
     }
     
     var body: some View {
@@ -27,7 +38,7 @@ struct SubjectCard: View {
             
             if shouldShowEmptyState {
                 emptyStateView
-            } else if let study = firstStudy {
+            } else if let study = priorityStudy {
                 normalStateView(study: study)
             }
         }

--- a/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/AddStudyView.swift
+++ b/BBANGZIP/BBANGZIP/Sources/Presentation/Main/View/AddStudyView.swift
@@ -109,6 +109,7 @@ struct AddStudyView: View {
     // TODO: 뒤로가기 버튼 ToolBar로 리팩토링 필요
     private var backButton: some View {
         Button {
+            dismiss()
         } label: { HStack {
                 Image(.chevronLeftThickSmall)
                     .renderingMode(.template)


### PR DESCRIPTION
## 🥖 What is the PR?

Subject examName 필터링 내부 로직 구현 

## 🥐 Changes

- SubjectCard에서 examName으로 필터링
- AddStudyView Dismiss 추가

## 🥯 Thoughts

- studyList가 비어있어, examDday가 999인 경우, 중간고사 정보 존재, 기말고사 정보 존재 경우에 따른 필터링

## 🥪 Screenshot

| 메인화면 | 
| ![Uploading Simulator Screenshot - iPhone 13 mini - 2025-01-25 at 14.44.33.png…]()| 


## 🥨 To Reviewers

- 시험 정보가 있을때 빈객체가 뜨지 않도록 수정하였습니다.

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #124 
